### PR TITLE
Initialize Diana voice notes app skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Decode google services
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
+      - name: Build
+        run: ./gradlew assembleDebug
+      - name: Firebase App Distribution
+        if: success()
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          groups: ${{ secrets.FIREBASE_TESTERS_GROUPS }}
+          file: app/build/outputs/apk/debug/app-debug.apk

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,56 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+    id 'com.google.gms.google-services'
+    id 'com.google.firebase.crashlytics'
+}
+
+android {
+    namespace 'li.crescio.penates.diana'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'li.crescio.penates.diana'
+        minSdk 26
+        targetSdk 34
+        versionCode 1
+        versionName '0.1'
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        buildConfigField "String", "GROQ_API_KEY", "\"${readConf('GROQ_API_KEY')}\""
+        buildConfigField "String", "OPENROUTER_API_KEY", "\"${readConf('OPENROUTER_API_KEY')}\""
+    }
+
+    buildFeatures {
+        compose true
+        buildConfig true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion compose_ui_version
+    }
+
+    packagingOptions {
+        resources {
+            excludes += '/META-INF/{AL2.0,LGPL2.1}'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.activity:activity-compose:1.8.2'
+    implementation "androidx.compose.ui:ui:$compose_ui_version"
+    implementation "androidx.compose.material3:material3:1.2.1"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation platform('com.google.firebase:firebase-bom:32.7.3')
+    implementation 'com.google.firebase:firebase-crashlytics-ktx'
+    implementation 'com.google.firebase:firebase-analytics-ktx'
+    implementation 'com.google.firebase:firebase-firestore-ktx'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
+    debugImplementation "androidx.compose.ui:ui-tooling:$compose_ui_version"
+    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_ui_version"
+}

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,23 @@
+{
+  "project_info": {
+    "project_number": "1234567890",
+    "project_id": "diana-demo"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:1234567890:android:abcdef",
+        "android_client_info": {
+          "package_name": "li.crescio.penates.diana"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDUMMYKEY"
+        }
+      ]
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<manifest package="li.crescio.penates.diana" xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Diana">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -1,0 +1,38 @@
+package li.crescio.penates.diana
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.*
+import li.crescio.penates.diana.notes.StructuredNote
+import li.crescio.penates.diana.ui.*
+import li.crescio.penates.diana.ui.theme.DianaTheme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { DianaTheme { DianaApp() } }
+    }
+}
+
+@Composable
+fun DianaApp() {
+    var screen by remember { mutableStateOf<Screen>(Screen.List) }
+    val notes = remember { mutableStateListOf<StructuredNote>() }
+
+    when (screen) {
+        Screen.List -> NotesListScreen(notes) { screen = Screen.Recorder }
+        Screen.Recorder -> RecorderScreen {
+            notes.add(StructuredNote.Memo("Sample")); screen = Screen.List
+        }
+        Screen.Processing -> ProcessingScreen("Processing...") { screen = Screen.List }
+        Screen.Settings -> SettingsScreen()
+    }
+}
+
+sealed class Screen {
+    data object List : Screen()
+    data object Recorder : Screen()
+    data object Processing : Screen()
+    data object Settings : Screen()
+}

--- a/app/src/main/java/li/crescio/penates/diana/llm/NoteInterpreter.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/NoteInterpreter.kt
@@ -1,0 +1,33 @@
+package li.crescio.penates.diana.llm
+
+import li.crescio.penates.diana.notes.StructuredNote
+import li.crescio.penates.diana.notes.Transcript
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+class NoteInterpreter(private val apiKey: String, private val logger: LlmLogger) {
+    private val client = OkHttpClient()
+
+    suspend fun interpret(transcript: Transcript): List<StructuredNote> {
+        val requestBody = "{""input"": ""${transcript.text}""}""
+            .toRequestBody("application/json".toMediaType())
+        val request = Request.Builder()
+            .url("https://openrouter.ai/api/v1/chat/completions")
+            .header("Authorization", "Bearer $apiKey")
+            .post(requestBody)
+            .build()
+        val responseText = client.newCall(request).execute().use { it.body?.string() ?: "" }
+        logger.log(transcript.text, responseText)
+        return listOf(StructuredNote.Memo(transcript.text))
+    }
+}
+
+class LlmLogger {
+    private val logs = mutableListOf<String>()
+    fun log(request: String, response: String) {
+        logs += "REQUEST: $request\nRESPONSE: $response"
+    }
+    fun entries(): List<String> = logs
+}

--- a/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
+++ b/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
@@ -1,0 +1,14 @@
+package li.crescio.penates.diana.notes
+
+data class RawRecording(val filePath: String)
+
+data class Transcript(val text: String)
+
+sealed class StructuredNote {
+    data class ToDo(val text: String) : StructuredNote()
+    data class Memo(val text: String) : StructuredNote()
+    data class Event(val text: String, val datetime: String) : StructuredNote()
+    data class Free(val text: String) : StructuredNote()
+}
+
+data class NoteCollection(val notes: List<StructuredNote>)

--- a/app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt
+++ b/app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt
@@ -1,0 +1,17 @@
+package li.crescio.penates.diana.persistence
+
+import com.google.firebase.firestore.FirebaseFirestore
+import li.crescio.penates.diana.notes.StructuredNote
+import java.io.File
+
+class NoteRepository(
+    private val firestore: FirebaseFirestore,
+    private val file: File
+) {
+    suspend fun saveNotes(notes: List<StructuredNote>) {
+        file.writeText(notes.joinToString("\n") { it.toString() })
+        firestore.collection("notes").add(mapOf("raw" to notes.map { it.toString() }))
+    }
+
+    suspend fun loadNotes(): List<StructuredNote> = emptyList()
+}

--- a/app/src/main/java/li/crescio/penates/diana/pipeline/ProcessingPipeline.kt
+++ b/app/src/main/java/li/crescio/penates/diana/pipeline/ProcessingPipeline.kt
@@ -1,0 +1,24 @@
+package li.crescio.penates.diana.pipeline
+
+import li.crescio.penates.diana.notes.RawRecording
+import li.crescio.penates.diana.notes.StructuredNote
+import li.crescio.penates.diana.notes.Transcript
+
+data class PipelineContext(
+    val recording: RawRecording,
+    val transcript: Transcript? = null,
+    val notes: List<StructuredNote> = emptyList()
+)
+
+interface PipelineStep {
+    suspend fun process(context: PipelineContext): PipelineContext
+}
+
+class ProcessingPipeline(private val steps: List<PipelineStep>) {
+    suspend fun execute(recording: RawRecording) {
+        var ctx = PipelineContext(recording)
+        steps.forEach { step ->
+            ctx = step.process(ctx)
+        }
+    }
+}

--- a/app/src/main/java/li/crescio/penates/diana/pipeline/Steps.kt
+++ b/app/src/main/java/li/crescio/penates/diana/pipeline/Steps.kt
@@ -1,0 +1,36 @@
+package li.crescio.penates.diana.pipeline
+
+import li.crescio.penates.diana.llm.NoteInterpreter
+import li.crescio.penates.diana.notes.StructuredNote
+import li.crescio.penates.diana.notes.Transcript
+import li.crescio.penates.diana.persistence.NoteRepository
+import li.crescio.penates.diana.transcriber.Transcriber
+
+class TranscriptionStep(private val transcriber: Transcriber) : PipelineStep {
+    override suspend fun process(context: PipelineContext): PipelineContext {
+        val transcript = transcriber.transcribe(context.recording)
+        return context.copy(transcript = transcript)
+    }
+}
+
+class InterpretationStep(private val interpreter: NoteInterpreter) : PipelineStep {
+    override suspend fun process(context: PipelineContext): PipelineContext {
+        val transcript = context.transcript ?: Transcript("")
+        val notes: List<StructuredNote> = interpreter.interpret(transcript)
+        return context.copy(notes = notes)
+    }
+}
+
+class PersistenceStep(private val repository: NoteRepository) : PipelineStep {
+    override suspend fun process(context: PipelineContext): PipelineContext {
+        repository.saveNotes(context.notes)
+        return context
+    }
+}
+
+class CallbackStep(private val callback: (PipelineContext) -> Unit) : PipelineStep {
+    override suspend fun process(context: PipelineContext): PipelineContext {
+        callback(context)
+        return context
+    }
+}

--- a/app/src/main/java/li/crescio/penates/diana/recorder/AndroidRecorder.kt
+++ b/app/src/main/java/li/crescio/penates/diana/recorder/AndroidRecorder.kt
@@ -1,0 +1,10 @@
+package li.crescio.penates.diana.recorder
+
+import li.crescio.penates.diana.notes.RawRecording
+
+class AndroidRecorder : Recorder {
+    override suspend fun record(): RawRecording {
+        // Placeholder for audio recording implementation
+        return RawRecording("")
+    }
+}

--- a/app/src/main/java/li/crescio/penates/diana/recorder/Recorder.kt
+++ b/app/src/main/java/li/crescio/penates/diana/recorder/Recorder.kt
@@ -1,0 +1,7 @@
+package li.crescio.penates.diana.recorder
+
+import li.crescio.penates.diana.notes.RawRecording
+
+interface Recorder {
+    suspend fun record(): RawRecording
+}

--- a/app/src/main/java/li/crescio/penates/diana/transcriber/GroqTranscriber.kt
+++ b/app/src/main/java/li/crescio/penates/diana/transcriber/GroqTranscriber.kt
@@ -1,0 +1,23 @@
+package li.crescio.penates.diana.transcriber
+
+import li.crescio.penates.diana.notes.RawRecording
+import li.crescio.penates.diana.notes.Transcript
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+class GroqTranscriber(private val apiKey: String) : Transcriber {
+    private val client = OkHttpClient()
+
+    override suspend fun transcribe(recording: RawRecording): Transcript {
+        // Simplified network request placeholder
+        val request = Request.Builder()
+            .url("https://api.groq.com/openai/v1/audio/transcriptions")
+            .header("Authorization", "Bearer $apiKey")
+            .post("".toRequestBody("application/octet-stream".toMediaType()))
+            .build()
+        client.newCall(request).execute().use { }
+        return Transcript("")
+    }
+}

--- a/app/src/main/java/li/crescio/penates/diana/transcriber/LocalTranscriber.kt
+++ b/app/src/main/java/li/crescio/penates/diana/transcriber/LocalTranscriber.kt
@@ -1,0 +1,11 @@
+package li.crescio.penates.diana.transcriber
+
+import li.crescio.penates.diana.notes.RawRecording
+import li.crescio.penates.diana.notes.Transcript
+
+class LocalTranscriber : Transcriber {
+    override suspend fun transcribe(recording: RawRecording): Transcript {
+        // Placeholder for on-device SpeechRecognizer usage
+        return Transcript("")
+    }
+}

--- a/app/src/main/java/li/crescio/penates/diana/transcriber/Transcriber.kt
+++ b/app/src/main/java/li/crescio/penates/diana/transcriber/Transcriber.kt
@@ -1,0 +1,8 @@
+package li.crescio.penates.diana.transcriber
+
+import li.crescio.penates.diana.notes.RawRecording
+import li.crescio.penates.diana.notes.Transcript
+
+interface Transcriber {
+    suspend fun transcribe(recording: RawRecording): Transcript
+}

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -1,0 +1,21 @@
+package li.crescio.penates.diana.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import li.crescio.penates.diana.notes.StructuredNote
+
+@Composable
+fun NotesListScreen(notes: List<StructuredNote>, onRecord: () -> Unit) {
+    Column {
+        Button(onClick = onRecord) { Text("Record") }
+        LazyColumn {
+            items(notes) { note ->
+                Text(note.toString())
+            }
+        }
+    }
+}

--- a/app/src/main/java/li/crescio/penates/diana/ui/ProcessingScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/ProcessingScreen.kt
@@ -1,0 +1,9 @@
+package li.crescio.penates.diana.ui
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ProcessingScreen(status: String, onDone: () -> Unit) {
+    Text(status)
+}

--- a/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
@@ -1,0 +1,10 @@
+package li.crescio.penates.diana.ui
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun RecorderScreen(onFinish: () -> Unit) {
+    Button(onClick = onFinish) { Text("Finish Recording") }
+}

--- a/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
@@ -1,0 +1,9 @@
+package li.crescio.penates.diana.ui
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun SettingsScreen() {
+    Text("Settings")
+}

--- a/app/src/main/java/li/crescio/penates/diana/ui/theme/Theme.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/theme/Theme.kt
@@ -1,0 +1,12 @@
+package li.crescio.penates.diana.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+
+@Composable
+fun DianaTheme(content: @Composable () -> Unit) {
+    MaterialTheme {
+        Surface { content() }
+    }
+}

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path android:fillColor="#3DDC84" android:pathData="M0,0h108v108h-108z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path android:fillColor="#FFFFFF" android:pathData="M54,16L90,92H18z"/>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background"/>
+    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background"/>
+    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Diana</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.Diana" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,45 @@
+buildscript {
+    ext {
+        compose_ui_version = '1.6.7'
+    }
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22'
+        classpath 'com.google.gms:google-services:4.4.1'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+ext.readConf = { key ->
+    if (project.hasProperty(key)) {
+        return project.property(key)
+    }
+    def env = System.getenv(key)
+    if (env != null) {
+        return env
+    }
+    def localPropFile = rootProject.file("local.properties")
+    if (localPropFile.exists()) {
+        def props = new Properties()
+        props.load(localPropFile.newDataInputStream())
+        if (props[key] != null) {
+            return props[key]
+        }
+    }
+    return ""
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# Architecture
+
+Diana records voice notes and transforms them into structured items. The
+application uses several modules:
+
+- `recorder` captures audio from the device.
+- `transcriber` turns audio into text.
+- `llm` interprets transcripts into notes.
+- `persistence` stores notes locally and in Firebase.
+- `notes` defines core domain models.
+- `ui` presents a Compose based interface.
+
+The processing pipeline moves a recording through four ordered steps:
+
+1. **TranscriptionStep** converts audio clips into text.
+2. **InterpretationStep** calls the language model to build structured notes.
+3. **PersistenceStep** saves notes to Firestore and to a local file.
+4. **CallbackStep** reports progress back to the user interface.
+
+Data flows from the microphone to persistent storage in the following order:
+
+recording → transcription → LLM processing → structured notes → persistence
+→ display.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,31 @@
+# Deployment
+
+## Firebase setup
+
+1. Create a Firebase project named `diana`.
+2. Enable Firestore, Crashlytics, and Analytics.
+3. In the console add an Android app with the package
+   `li.crescio.penates.diana`.
+4. Download `google-services.json` and place it in `app/`.
+5. Generate a service account key for CI and store it as the secret
+   `FIREBASE_SERVICE_ACCOUNT`.
+
+## GitHub Actions
+
+A workflow builds and distributes debug builds through Firebase App
+Distribution. Configure the repository with these secrets:
+
+- `FIREBASE_SERVICE_ACCOUNT` – base64 encoded service account JSON.
+- `FIREBASE_APP_ID` – the app id from Firebase.
+- `FIREBASE_TESTERS_GROUPS` – comma separated tester groups.
+- `GOOGLE_SERVICES_JSON` – contents of `google-services.json`.
+
+The workflow runs on pushes to `main` and publishes the APK to the testers
+group.
+
+## Local builds
+
+1. Install JDK 17 and the Android SDK.
+2. Set environment variables for `GROQ_API_KEY` and `OPENROUTER_API_KEY`.
+3. Open the project in Android Studio and let Gradle sync.
+4. Run `./gradlew assembleDebug` to build and install on a device.

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -1,0 +1,12 @@
+# Notes
+
+A `StructuredNote` represents an item extracted from a transcript. Four types
+are supported:
+
+- **ToDo** for actionable tasks.
+- **Memo** for free form text snippets.
+- **Event** for calendar entries with optional date and time.
+- **Free** for content that does not fit other categories.
+
+Notes are grouped in a `NoteCollection` to represent a session or a day. Each
+note keeps only essential information to remain lightweight and portable.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/samples/sample_session.json
+++ b/samples/sample_session.json
@@ -1,0 +1,11 @@
+{
+  "recordings": [
+    {
+      "file": "sample1.m4a",
+      "transcript": "Buy milk tomorrow",
+      "notes": [
+        { "type": "todo", "text": "Buy milk" }
+      ]
+    }
+  ]
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "Diana"
+include(":app")


### PR DESCRIPTION
## Summary
- configure Gradle with helper to read configuration values
- add Android app module with domain models, processing pipeline, transcriber and interpreter stubs, persistence layer, and Compose UI screens
- document architecture, note formats, and deployment, and add CI workflow for Firebase distribution

## Testing
- `./gradlew lint test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b607caf6d48325942bb7a20ced9e19