### PR TITLE
Add Material Components dependency for Material3 theme

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.8.2'
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation "androidx.compose.material3:material3:1.2.1"
+    implementation 'com.google.android.material:material:1.11.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation platform('com.google.firebase:firebase-bom:32.7.3')


### PR DESCRIPTION
## Summary
- add Material Components dependency so Material3 themes are available

## Testing
- `./gradlew build` *(fails: SDK location not found)*
- `./gradlew :app:dependencies`


------
https://chatgpt.com/codex/tasks/task_e_68b60e9e2b088325a76d6969bbaa69ff