### PR TITLE
Specify Compose compiler version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion compose_ui_version
+        kotlinCompilerExtensionVersion '1.5.10'
     }
 
     packagingOptions {


### PR DESCRIPTION
## Summary
- use Compose compiler extension 1.5.10 to match Kotlin 1.9.22

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b611a5a0948325b056c2933b1c29b2