### PR TITLE
Improve recording UI layout with log console

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -19,11 +19,14 @@ class MainActivity : ComponentActivity() {
 fun DianaApp() {
     var screen by remember { mutableStateOf<Screen>(Screen.List) }
     val notes = remember { mutableStateListOf<StructuredNote>() }
+    val logs = remember { mutableStateListOf<String>() }
 
     when (screen) {
-        Screen.List -> NotesListScreen(notes) { screen = Screen.Recorder }
+        Screen.List -> NotesListScreen(notes, logs) { screen = Screen.Recorder }
         Screen.Recorder -> RecorderScreen {
-            notes.add(StructuredNote.Memo("Sample")); screen = Screen.List
+            notes.add(StructuredNote.Memo("Sample"))
+            logs.add("Recorded memo")
+            screen = Screen.List
         }
         Screen.Processing -> ProcessingScreen("Processing...") { screen = Screen.List }
         Screen.Settings -> SettingsScreen()

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -1,20 +1,59 @@
 package li.crescio.penates.diana.ui
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
 import li.crescio.penates.diana.notes.StructuredNote
 
 @Composable
-fun NotesListScreen(notes: List<StructuredNote>, onRecord: () -> Unit) {
-    Column {
-        Button(onClick = onRecord) { Text("Record") }
-        LazyColumn {
+fun NotesListScreen(
+    notes: List<StructuredNote>,
+    logs: List<String>,
+    onRecord: () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Button(onClick = onRecord) { Text("Record") }
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 16.dp)
+        ) {
             items(notes) { note ->
                 Text(note.toString())
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp)
+                .background(Color.Black)
+        ) {
+            LazyColumn(modifier = Modifier.padding(8.dp)) {
+                items(logs) { log ->
+                    Text(
+                        log,
+                        fontFamily = FontFamily.Monospace,
+                        color = Color.Green
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
@@ -1,10 +1,16 @@
 package li.crescio.penates.diana.ui
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 
 @Composable
 fun RecorderScreen(onFinish: () -> Unit) {
-    Button(onClick = onFinish) { Text("Finish Recording") }
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Button(onClick = onFinish) { Text("Finish Recording") }
+    }
 }


### PR DESCRIPTION
## Summary
- Center the recording controls on the notes screen and during recording
- Add scrolling area for notes and terminal-style log console
- Track log messages and display them on the main screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6998f0f708325b5b9922ae12f5a5b