### PR TITLE
Show logs during recording

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -23,7 +23,7 @@ fun DianaApp() {
 
     when (screen) {
         Screen.List -> NotesListScreen(notes, logs) { screen = Screen.Recorder }
-        Screen.Recorder -> RecorderScreen {
+        Screen.Recorder -> RecorderScreen(logs) {
             notes.add(StructuredNote.Memo("Sample"))
             logs.add("Recorded memo")
             screen = Screen.List

--- a/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
@@ -1,16 +1,45 @@
 package li.crescio.penates.diana.ui
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
 
 @Composable
-fun RecorderScreen(onFinish: () -> Unit) {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Button(onClick = onFinish) { Text("Finish Recording") }
+fun RecorderScreen(logs: List<String>, onFinish: () -> Unit) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            Button(onClick = onFinish) { Text("Finish Recording") }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp)
+                .background(Color.Black)
+        ) {
+            LazyColumn(modifier = Modifier.padding(8.dp)) {
+                items(logs) { log ->
+                    Text(
+                        log,
+                        fontFamily = FontFamily.Monospace,
+                        color = Color.Green
+                    )
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Display logs on the recorder screen to keep them visible while recording
- Pass shared log list from the main activity to the recorder screen

## Testing
- `./gradlew test --console=plain --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b69f8d4ba08325bbaebb219351aa6b