### PR TITLE
Add flexible processing pipeline

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/pipeline/Steps.kt
+++ b/app/src/main/java/li/crescio/penates/diana/pipeline/Steps.kt
@@ -3,17 +3,41 @@ package li.crescio.penates.diana.pipeline
 import li.crescio.penates.diana.llm.NoteInterpreter
 import li.crescio.penates.diana.notes.StructuredNote
 import li.crescio.penates.diana.notes.Transcript
-import li.crescio.penates.diana.persistence.NoteRepository
 import li.crescio.penates.diana.transcriber.Transcriber
 
-class TranscriptionStep(private val transcriber: Transcriber) : PipelineStep {
+/**
+ * Transcribes the raw recording into text.
+ *
+ * @param transcriber the engine performing the transcription
+ * @param enabled whether this step should run. Future pipelines can disable
+ *        steps without removing them from the chain.
+ */
+class TranscriptionStep(
+    private val transcriber: Transcriber,
+    private val enabled: Boolean = true,
+) : PipelineStep {
+
+    override suspend fun shouldProcess(context: PipelineContext): Boolean = enabled
+
     override suspend fun process(context: PipelineContext): PipelineContext {
         val transcript = transcriber.transcribe(context.recording)
         return context.copy(transcript = transcript)
     }
 }
 
-class InterpretationStep(private val interpreter: NoteInterpreter) : PipelineStep {
+/**
+ * Uses a large language model to interpret the transcript into structured notes.
+ *
+ * @param interpreter the LLM adapter
+ * @param enabled whether this step should run
+ */
+class InterpretationStep(
+    private val interpreter: NoteInterpreter,
+    private val enabled: Boolean = true,
+) : PipelineStep {
+
+    override suspend fun shouldProcess(context: PipelineContext): Boolean = enabled
+
     override suspend fun process(context: PipelineContext): PipelineContext {
         val transcript = context.transcript ?: Transcript("")
         val notes: List<StructuredNote> = interpreter.interpret(transcript)
@@ -21,16 +45,3 @@ class InterpretationStep(private val interpreter: NoteInterpreter) : PipelineSte
     }
 }
 
-class PersistenceStep(private val repository: NoteRepository) : PipelineStep {
-    override suspend fun process(context: PipelineContext): PipelineContext {
-        repository.saveNotes(context.notes)
-        return context
-    }
-}
-
-class CallbackStep(private val callback: (PipelineContext) -> Unit) : PipelineStep {
-    override suspend fun process(context: PipelineContext): PipelineContext {
-        callback(context)
-        return context
-    }
-}


### PR DESCRIPTION
## Summary
- introduce pipeline step interface with conditional execution
- allow processing pipeline to skip disabled steps and return final context
- add transcription and interpretation steps with optional enable flags

## Testing
- `./gradlew test --dry-run --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b69fcae9e883259b3c4868d8c07b0e