### PR TITLE
Add recorded note review with playback

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -4,7 +4,10 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.*
+import li.crescio.penates.diana.notes.RecordedNote
 import li.crescio.penates.diana.notes.StructuredNote
+import li.crescio.penates.diana.player.AndroidPlayer
+import li.crescio.penates.diana.player.Player
 import li.crescio.penates.diana.ui.*
 import li.crescio.penates.diana.ui.theme.DianaTheme
 
@@ -19,14 +22,17 @@ class MainActivity : ComponentActivity() {
 fun DianaApp() {
     var screen by remember { mutableStateOf<Screen>(Screen.List) }
     val notes = remember { mutableStateListOf<StructuredNote>() }
+    val recordedNotes = remember { mutableStateListOf<RecordedNote>() }
     val logs = remember { mutableStateListOf<String>() }
+    val player: Player = remember { AndroidPlayer() }
 
     when (screen) {
-        Screen.List -> NotesListScreen(notes, logs) { screen = Screen.Recorder }
-        Screen.Recorder -> RecorderScreen(logs) {
-            notes.add(StructuredNote.Memo("Sample"))
-            logs.add("Recorded memo")
-            screen = Screen.List
+        Screen.List -> NotesListScreen(notes, logs, onRecord = { screen = Screen.Recorder }) { screen = Screen.Recordings }
+        Screen.Recordings -> RecordedNotesScreen(recordedNotes, player) { screen = Screen.List }
+        Screen.Recorder -> RecorderScreen(logs) { note ->
+            recordedNotes.add(note)
+            logs.add("Recorded note")
+            screen = Screen.Recordings
         }
         Screen.Processing -> ProcessingScreen("Processing...") { screen = Screen.List }
         Screen.Settings -> SettingsScreen()
@@ -35,6 +41,7 @@ fun DianaApp() {
 
 sealed class Screen {
     data object List : Screen()
+    data object Recordings : Screen()
     data object Recorder : Screen()
     data object Processing : Screen()
     data object Settings : Screen()

--- a/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
+++ b/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
@@ -4,6 +4,14 @@ data class RawRecording(val filePath: String)
 
 data class Transcript(val text: String)
 
+/**
+ * A captured audio note and its raw transcript prior to any processing.
+ */
+data class RecordedNote(
+    val recording: RawRecording,
+    val transcript: Transcript
+)
+
 sealed class StructuredNote {
     data class ToDo(val text: String) : StructuredNote()
     data class Memo(val text: String) : StructuredNote()

--- a/app/src/main/java/li/crescio/penates/diana/player/AndroidPlayer.kt
+++ b/app/src/main/java/li/crescio/penates/diana/player/AndroidPlayer.kt
@@ -1,0 +1,17 @@
+package li.crescio.penates.diana.player
+
+import android.media.MediaPlayer
+
+/** Plays audio files using [MediaPlayer]. */
+class AndroidPlayer : Player {
+    override fun play(filePath: String) {
+        val player = MediaPlayer()
+        try {
+            player.setDataSource(filePath)
+            player.prepare()
+            player.start()
+        } catch (e: Exception) {
+            // Swallow exceptions for this simplified implementation
+        }
+    }
+}

--- a/app/src/main/java/li/crescio/penates/diana/player/Player.kt
+++ b/app/src/main/java/li/crescio/penates/diana/player/Player.kt
@@ -1,0 +1,6 @@
+package li.crescio.penates.diana.player
+
+/** Simple abstraction for playing back audio recordings. */
+interface Player {
+    fun play(filePath: String)
+}

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -18,16 +18,19 @@ import li.crescio.penates.diana.notes.StructuredNote
 fun NotesListScreen(
     notes: List<StructuredNote>,
     logs: List<String>,
-    onRecord: () -> Unit
+    onRecord: () -> Unit,
+    onViewRecordings: () -> Unit
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
-        Box(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 16.dp),
-            contentAlignment = Alignment.Center
+            horizontalArrangement = Arrangement.Center
         ) {
             Button(onClick = onRecord) { Text("Record") }
+            Spacer(modifier = Modifier.width(16.dp))
+            Button(onClick = onViewRecordings) { Text("View Recordings") }
         }
 
         LazyColumn(

--- a/app/src/main/java/li/crescio/penates/diana/ui/RecordedNotesScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecordedNotesScreen.kt
@@ -1,0 +1,46 @@
+package li.crescio.penates.diana.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import li.crescio.penates.diana.notes.RecordedNote
+import li.crescio.penates.diana.player.Player
+
+@Composable
+fun RecordedNotesScreen(
+    notes: List<RecordedNote>,
+    player: Player,
+    onBack: () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Button(onClick = onBack) { Text("Back") }
+        }
+
+        LazyColumn(modifier = Modifier.weight(1f).padding(horizontal = 16.dp)) {
+            items(notes) { note ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+                ) {
+                    Button(onClick = { player.play(note.recording.filePath) }) { Text("Play") }
+                    Text(
+                        note.transcript.text,
+                        modifier = Modifier.padding(start = 16.dp)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
@@ -12,9 +12,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import li.crescio.penates.diana.notes.RecordedNote
+import li.crescio.penates.diana.notes.RawRecording
+import li.crescio.penates.diana.notes.Transcript
 
 @Composable
-fun RecorderScreen(logs: List<String>, onFinish: () -> Unit) {
+fun RecorderScreen(logs: List<String>, onFinish: (RecordedNote) -> Unit) {
     Column(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
@@ -22,7 +25,12 @@ fun RecorderScreen(logs: List<String>, onFinish: () -> Unit) {
                 .fillMaxWidth(),
             contentAlignment = Alignment.Center
         ) {
-            Button(onClick = onFinish) { Text("Finish Recording") }
+            Button(onClick = {
+                // Stub recording and transcription
+                val recording = RawRecording("sample.wav")
+                val transcript = Transcript("Sample transcription")
+                onFinish(RecordedNote(recording, transcript))
+            }) { Text("Finish Recording") }
         }
 
         Box(


### PR DESCRIPTION
## Summary
- Track recorded audio notes alongside their raw transcripts
- Allow reviewing and playing back recordings before processing
- Wire new recorded-notes screen into main app navigation

## Testing
- `./gradlew test --console=plain --no-daemon` *(fails: process stalled, likely missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b0384ac48325a48094ecfc45fc46