### PR TITLE
Use Groq transcript in recorder

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
@@ -6,18 +6,29 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import li.crescio.penates.diana.BuildConfig
 import li.crescio.penates.diana.notes.RecordedNote
-import li.crescio.penates.diana.notes.RawRecording
-import li.crescio.penates.diana.notes.Transcript
+import li.crescio.penates.diana.recorder.AndroidRecorder
+import li.crescio.penates.diana.transcriber.GroqTranscriber
 
 @Composable
 fun RecorderScreen(logs: List<String>, onFinish: (RecordedNote) -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val recorder = remember { AndroidRecorder(context) }
+    val transcriber = remember { GroqTranscriber(BuildConfig.GROQ_API_KEY) }
+
+    LaunchedEffect(Unit) { recorder.start() }
+
     Column(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
@@ -26,10 +37,11 @@ fun RecorderScreen(logs: List<String>, onFinish: (RecordedNote) -> Unit) {
             contentAlignment = Alignment.Center
         ) {
             Button(onClick = {
-                // Stub recording and transcription
-                val recording = RawRecording("sample.wav")
-                val transcript = Transcript("Sample transcription")
-                onFinish(RecordedNote(recording, transcript))
+                scope.launch {
+                    val recording = recorder.stop()
+                    val transcript = transcriber.transcribe(recording)
+                    onFinish(RecordedNote(recording, transcript))
+                }
             }) { Text("Finish Recording") }
         }
 


### PR DESCRIPTION
## Summary
- Replace stubbed recording/transcription with real Groq transcription
- Start microphone capture on opening recorder screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c4eec64c8325b30212b30049d30f