### PR TITLE
feat: allow adding memos via text

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -27,13 +27,24 @@ fun DianaApp() {
     val player: Player = remember { AndroidPlayer() }
 
     when (screen) {
-        Screen.List -> NotesListScreen(notes, logs, onRecord = { screen = Screen.Recorder }) { screen = Screen.Recordings }
+        Screen.List -> NotesListScreen(
+            notes,
+            logs,
+            onRecord = { screen = Screen.Recorder },
+            onViewRecordings = { screen = Screen.Recordings },
+            onAddMemo = { screen = Screen.TextMemo }
+        )
         Screen.Recordings -> RecordedNotesScreen(recordedNotes, player) { screen = Screen.List }
         Screen.Recorder -> RecorderScreen(logs) { note ->
             recordedNotes.add(note)
             logs.add("Recorded note")
             screen = Screen.Recordings
         }
+        Screen.TextMemo -> TextMemoScreen(onSave = { text ->
+            notes.add(StructuredNote.Memo(text))
+            logs.add("Added memo")
+            screen = Screen.List
+        })
         Screen.Processing -> ProcessingScreen("Processing...") { screen = Screen.List }
         Screen.Settings -> SettingsScreen()
     }
@@ -43,6 +54,7 @@ sealed class Screen {
     data object List : Screen()
     data object Recordings : Screen()
     data object Recorder : Screen()
+    data object TextMemo : Screen()
     data object Processing : Screen()
     data object Settings : Screen()
 }

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -19,7 +19,8 @@ fun NotesListScreen(
     notes: List<StructuredNote>,
     logs: List<String>,
     onRecord: () -> Unit,
-    onViewRecordings: () -> Unit
+    onViewRecordings: () -> Unit,
+    onAddMemo: () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         Row(
@@ -29,6 +30,8 @@ fun NotesListScreen(
             horizontalArrangement = Arrangement.Center
         ) {
             Button(onClick = onRecord) { Text("Record") }
+            Spacer(modifier = Modifier.width(16.dp))
+            Button(onClick = onAddMemo) { Text("Text Memo") }
             Spacer(modifier = Modifier.width(16.dp))
             Button(onClick = onViewRecordings) { Text("View Recordings") }
         }

--- a/app/src/main/java/li/crescio/penates/diana/ui/TextMemoScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/TextMemoScreen.kt
@@ -1,0 +1,29 @@
+package li.crescio.penates.diana.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TextMemoScreen(onSave: (String) -> Unit) {
+    var text by remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        TextField(
+            value = text,
+            onValueChange = { text = it },
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = { if (text.isNotBlank()) onSave(text) }, modifier = Modifier.align(Alignment.End)) {
+            Text("Save")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add TextMemoScreen to input memo text manually
- show button on notes list to open memo input
- wire screen into app navigation

## Testing
- `./gradlew test` *(fails: No matching client found for package name 'li.crescio.penates.diana')*


------
https://chatgpt.com/codex/tasks/task_e_68b6dfff6f4c83259a67f93886424710