### PR TITLE
Move transcription request off main thread

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- Add Internet permission for network access
- Run Groq transcription request on Dispatchers.IO to avoid blocking main thread

## Testing
- `./gradlew test` *(fails: No matching client found for package name 'li.crescio.penates.diana' in app/google-services.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fba545f4832593bc1fc846c4074a