### PR TITLE
Fix logs LazyColumn items import in NotesListScreen

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -3,6 +3,7 @@ package li.crescio.penates.diana.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
## Summary
- import LazyColumn `items` to iterate over log entries

## Testing
- `./gradlew test` *(fails: No matching client found for package name 'li.crescio.penates.diana' in google-services.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b713e585ac83259d8aee62350848d7