### PR TITLE
Handle LLM network call off main thread

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -1,6 +1,8 @@
 package li.crescio.penates.diana.llm
 
 import li.crescio.penates.diana.notes.Memo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -53,7 +55,9 @@ class MemoProcessor(private val apiKey: String, private val logger: LlmLogger) {
             .header("Authorization", "Bearer $apiKey")
             .post(requestBody)
             .build()
-        val responseText = client.newCall(request).execute().use { it.body?.string().orEmpty() }
+        val responseText = withContext(Dispatchers.IO) {
+            client.newCall(request).execute().use { it.body?.string().orEmpty() }
+        }
         logger.log(json, responseText)
 
         val content = JSONObject(responseText)


### PR DESCRIPTION
## Summary
- avoid NetworkOnMainThreadException by running OkHttp request on Dispatchers.IO

## Testing
- `./gradlew test` *(fails: No matching client found for package name 'li.crescio.penates.diana' in app/google-services.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b717dfb9cc8325b3d2859db4485a99