### PR TITLE
Add localization and locale-aware LLM prompts

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.*
+import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.launch
 import li.crescio.penates.diana.llm.LlmLogger
 import li.crescio.penates.diana.llm.MemoProcessor
@@ -12,6 +13,8 @@ import li.crescio.penates.diana.player.AndroidPlayer
 import li.crescio.penates.diana.player.Player
 import li.crescio.penates.diana.ui.*
 import li.crescio.penates.diana.ui.theme.DianaTheme
+import li.crescio.penates.diana.R
+import java.util.Locale
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,8 +32,11 @@ fun DianaApp() {
     var appointments by remember { mutableStateOf("") }
     var thoughts by remember { mutableStateOf("") }
     val scope = rememberCoroutineScope()
-    val processor = remember { MemoProcessor(BuildConfig.OPENROUTER_API_KEY, LlmLogger()) }
+    val processor = remember { MemoProcessor(BuildConfig.OPENROUTER_API_KEY, LlmLogger(), Locale.getDefault()) }
     val player: Player = remember { AndroidPlayer() }
+    val logRecorded = stringResource(R.string.log_recorded_memo)
+    val logAdded = stringResource(R.string.log_added_memo)
+    val processingText = stringResource(R.string.processing)
 
     fun processMemo(memo: Memo) {
         scope.launch {
@@ -54,17 +60,17 @@ fun DianaApp() {
         Screen.Recordings -> RecordedMemosScreen(recordedMemos, player) { screen = Screen.List }
         Screen.Recorder -> RecorderScreen(logs) { memo ->
             recordedMemos.add(memo)
-            logs.add("Recorded memo")
+            logs.add(logRecorded)
             processMemo(memo)
             screen = Screen.List
         }
         Screen.TextMemo -> TextMemoScreen(onSave = { text ->
             val memo = Memo(text)
-            logs.add("Added memo")
+            logs.add(logAdded)
             processMemo(memo)
             screen = Screen.List
         })
-        Screen.Processing -> ProcessingScreen("Processing...") { screen = Screen.List }
+        Screen.Processing -> ProcessingScreen(processingText) { screen = Screen.List }
         Screen.Settings -> SettingsScreen()
     }
 }

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import li.crescio.penates.diana.R
 @Composable
 fun NotesListScreen(
     todo: String,
@@ -29,11 +31,11 @@ fun NotesListScreen(
                 .padding(vertical = 16.dp),
             horizontalArrangement = Arrangement.Center
         ) {
-            Button(onClick = onRecord) { Text("Record") }
+            Button(onClick = onRecord) { Text(stringResource(R.string.record)) }
             Spacer(modifier = Modifier.width(16.dp))
-            Button(onClick = onAddMemo) { Text("Text Memo") }
+            Button(onClick = onAddMemo) { Text(stringResource(R.string.text_memo)) }
             Spacer(modifier = Modifier.width(16.dp))
-            Button(onClick = onViewRecordings) { Text("View Recordings") }
+            Button(onClick = onViewRecordings) { Text(stringResource(R.string.view_recordings)) }
         }
 
         LazyColumn(
@@ -42,15 +44,15 @@ fun NotesListScreen(
                 .padding(horizontal = 16.dp)
         ) {
             item {
-                Text("To-Do List")
+                Text(stringResource(R.string.todo_list))
                 Text(todo, modifier = Modifier.padding(bottom = 16.dp))
             }
             item {
-                Text("Appointments")
+                Text(stringResource(R.string.appointments))
                 Text(appointments, modifier = Modifier.padding(bottom = 16.dp))
             }
             item {
-                Text("Thoughts & Notes")
+                Text(stringResource(R.string.thoughts_notes))
                 Text(thoughts)
             }
         }

--- a/app/src/main/java/li/crescio/penates/diana/ui/RecordedMemosScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecordedMemosScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import li.crescio.penates.diana.notes.Memo
 import li.crescio.penates.diana.player.Player
+import androidx.compose.ui.res.stringResource
+import li.crescio.penates.diana.R
 
 @Composable
 fun RecordedMemosScreen(
@@ -25,7 +27,7 @@ fun RecordedMemosScreen(
                 .padding(vertical = 16.dp),
             contentAlignment = Alignment.Center
         ) {
-            Button(onClick = onBack) { Text("Back") }
+            Button(onClick = onBack) { Text(stringResource(R.string.back)) }
         }
 
         LazyColumn(modifier = Modifier.weight(1f).padding(horizontal = 16.dp)) {
@@ -34,7 +36,7 @@ fun RecordedMemosScreen(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
                 ) {
-                    Button(onClick = { memo.audioPath?.let { player.play(it) } }) { Text("Play") }
+                    Button(onClick = { memo.audioPath?.let { player.play(it) } }) { Text(stringResource(R.string.play)) }
                     Text(
                         memo.text,
                         modifier = Modifier.padding(start = 16.dp)

--- a/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
@@ -17,12 +17,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.launch
 import li.crescio.penates.diana.BuildConfig
 import li.crescio.penates.diana.notes.Memo
 import li.crescio.penates.diana.recorder.AndroidRecorder
 import li.crescio.penates.diana.transcriber.GroqTranscriber
+import li.crescio.penates.diana.R
 
 @Composable
 fun RecorderScreen(logs: List<String>, onFinish: (Memo) -> Unit) {
@@ -73,7 +75,7 @@ fun RecorderScreen(logs: List<String>, onFinish: (Memo) -> Unit) {
                     }
                 },
                 enabled = isRecording
-            ) { Text("Finish Recording") }
+            ) { Text(stringResource(R.string.finish_recording)) }
         }
 
         Box(

--- a/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
@@ -2,8 +2,10 @@ package li.crescio.penates.diana.ui
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import li.crescio.penates.diana.R
 
 @Composable
 fun SettingsScreen() {
-    Text("Settings")
+    Text(stringResource(R.string.settings))
 }

--- a/app/src/main/java/li/crescio/penates/diana/ui/TextMemoScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/TextMemoScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import li.crescio.penates.diana.R
 
 @Composable
 fun TextMemoScreen(onSave: (String) -> Unit) {
@@ -23,7 +25,7 @@ fun TextMemoScreen(onSave: (String) -> Unit) {
         )
         Spacer(modifier = Modifier.height(16.dp))
         Button(onClick = { if (text.isNotBlank()) onSave(text) }, modifier = Modifier.align(Alignment.End)) {
-            Text("Save")
+            Text(stringResource(R.string.save))
         }
     }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="app_name">Diana</string>
+    <string name="record">Enregistrer</string>
+    <string name="text_memo">Mémo texte</string>
+    <string name="view_recordings">Voir les enregistrements</string>
+    <string name="todo_list">Liste de tâches</string>
+    <string name="appointments">Rendez-vous</string>
+    <string name="thoughts_notes">Pensées et notes</string>
+    <string name="back">Retour</string>
+    <string name="play">Lire</string>
+    <string name="settings">Paramètres</string>
+    <string name="finish_recording">Terminer l'enregistrement</string>
+    <string name="save">Sauvegarder</string>
+    <string name="processing">Traitement...</string>
+    <string name="log_recorded_memo">Mémo enregistré</string>
+    <string name="log_added_memo">Mémo ajouté</string>
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="app_name">Diana</string>
+    <string name="record">Registra</string>
+    <string name="text_memo">Nota di testo</string>
+    <string name="view_recordings">Vedi registrazioni</string>
+    <string name="todo_list">Lista di cose da fare</string>
+    <string name="appointments">Appuntamenti</string>
+    <string name="thoughts_notes">Pensieri e note</string>
+    <string name="back">Indietro</string>
+    <string name="play">Riproduci</string>
+    <string name="settings">Impostazioni</string>
+    <string name="finish_recording">Termina registrazione</string>
+    <string name="save">Salva</string>
+    <string name="processing">Elaborazione...</string>
+    <string name="log_recorded_memo">Memo registrato</string>
+    <string name="log_added_memo">Memo aggiunto</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,17 @@
 <resources>
     <string name="app_name">Diana</string>
+    <string name="record">Record</string>
+    <string name="text_memo">Text Memo</string>
+    <string name="view_recordings">View Recordings</string>
+    <string name="todo_list">To-Do List</string>
+    <string name="appointments">Appointments</string>
+    <string name="thoughts_notes">Thoughts &amp; Notes</string>
+    <string name="back">Back</string>
+    <string name="play">Play</string>
+    <string name="settings">Settings</string>
+    <string name="finish_recording">Finish Recording</string>
+    <string name="save">Save</string>
+    <string name="processing">Processing...</string>
+    <string name="log_recorded_memo">Recorded memo</string>
+    <string name="log_added_memo">Added memo</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add English, Italian and French string resources for menu items and logs
- Use localized strings across UI and forward device locale to MemoProcessor
- Localize LLM prompts with fallback to English and preserve memo language

## Testing
- `./gradlew test` *(fails: No matching client found for package name 'li.crescio.penates.diana')*

------
https://chatgpt.com/codex/tasks/task_e_68b71b6910148325b6223da9e01cd6ad