### PR TITLE
chore: update material components dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.8.2'
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation "androidx.compose.material3:material3:1.2.1"
-    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation platform('com.google.firebase:firebase-bom:32.7.3')


### PR DESCRIPTION
## Summary
- update Material Components to 1.12.0 to avoid invalid French string resource causing mergeDebugResources failure

## Testing
- `./gradlew assembleDebug --console=plain` *(fails: This version only understands SDK XML versions up to 3 but an SDK XML file of version 4 was encountered)*

------
https://chatgpt.com/codex/tasks/task_e_68b75672ccf483258b277b423d9cdaeb