### PR TITLE
Add detailed recorder logging

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -58,7 +58,7 @@ fun DianaApp() {
             onAddMemo = { screen = Screen.TextMemo }
         )
         Screen.Recordings -> RecordedMemosScreen(recordedMemos, player) { screen = Screen.List }
-        Screen.Recorder -> RecorderScreen(logs) { memo ->
+        Screen.Recorder -> RecorderScreen(logs, addLog = { logs.add(it) }) { memo ->
             recordedMemos.add(memo)
             logs.add(logRecorded)
             processMemo(memo)

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -14,4 +14,9 @@
     <string name="processing">Traitement…</string>
     <string name="log_recorded_memo">Mémo enregistré</string>
     <string name="log_added_memo">Mémo ajouté</string>
+    <string name="log_start_recording">Démarrage de l'enregistrement</string>
+    <string name="log_recording_started">Enregistrement démarré</string>
+    <string name="log_stop_recording">Arrêt de l'enregistrement</string>
+    <string name="log_transcription_complete">Transcription terminée</string>
+    <string name="log_transcription_failed">Échec de la transcription</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -14,4 +14,9 @@
     <string name="processing">Elaborazione...</string>
     <string name="log_recorded_memo">Memo registrato</string>
     <string name="log_added_memo">Memo aggiunto</string>
+    <string name="log_start_recording">Avvio registrazione</string>
+    <string name="log_recording_started">Registrazione avviata</string>
+    <string name="log_stop_recording">Arresto registrazione</string>
+    <string name="log_transcription_complete">Trascrizione completata</string>
+    <string name="log_transcription_failed">Trascrizione fallita</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,4 +14,9 @@
     <string name="processing">Processing...</string>
     <string name="log_recorded_memo">Recorded memo</string>
     <string name="log_added_memo">Added memo</string>
+    <string name="log_start_recording">Starting recording</string>
+    <string name="log_recording_started">Recording started</string>
+    <string name="log_stop_recording">Stopping recording</string>
+    <string name="log_transcription_complete">Transcription complete</string>
+    <string name="log_transcription_failed">Transcription failed</string>
 </resources>


### PR DESCRIPTION
## Summary
- log recorder start, stop, and transcription result events
- pass log messages into shared log state
- add localized strings for new log events

## Testing
- `./gradlew test` *(fails: No matching client found for package name in google-services.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba96125a008325b66648d7d4d2fc48