### PR TITLE
Expose LLM log flow to UI

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.*
 import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.collect
 import li.crescio.penates.diana.llm.LlmLogger
 import li.crescio.penates.diana.llm.MemoProcessor
 import li.crescio.penates.diana.notes.Memo
@@ -28,15 +29,20 @@ fun DianaApp() {
     var screen by remember { mutableStateOf<Screen>(Screen.List) }
     val recordedMemos = remember { mutableStateListOf<Memo>() }
     val logs = remember { mutableStateListOf<String>() }
+    val logger = remember { LlmLogger() }
     var todo by remember { mutableStateOf("") }
     var appointments by remember { mutableStateOf("") }
     var thoughts by remember { mutableStateOf("") }
     val scope = rememberCoroutineScope()
-    val processor = remember { MemoProcessor(BuildConfig.OPENROUTER_API_KEY, LlmLogger(), Locale.getDefault()) }
+    val processor = remember { MemoProcessor(BuildConfig.OPENROUTER_API_KEY, logger, Locale.getDefault()) }
     val player: Player = remember { AndroidPlayer() }
     val logRecorded = stringResource(R.string.log_recorded_memo)
     val logAdded = stringResource(R.string.log_added_memo)
     val processingText = stringResource(R.string.processing)
+
+    LaunchedEffect(logger) {
+        logger.logFlow.collect { logs.add(it) }
+    }
 
     fun processMemo(memo: Memo) {
         scope.launch {

--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -3,6 +3,9 @@ package li.crescio.penates.diana.llm
 import li.crescio.penates.diana.notes.Memo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -86,9 +89,15 @@ data class MemoSummary(val todo: String, val appointments: String, val thoughts:
 
 class LlmLogger {
     private val logs = mutableListOf<String>()
+    private val _logFlow = MutableSharedFlow<String>()
+    val logFlow: SharedFlow<String> = _logFlow.asSharedFlow()
+
     fun log(request: String, response: String) {
-        logs += "REQUEST: $request\nRESPONSE: $response"
+        val entry = "REQUEST: $request\nRESPONSE: $response"
+        logs += entry
+        _logFlow.tryEmit(entry)
     }
+
     fun entries(): List<String> = logs
 }
 


### PR DESCRIPTION
## Summary
- expose a `SharedFlow` of LLM log entries
- collect LLM logs in `MainActivity` and append to existing log list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9bdac1a083259f47cb94cfeb40d3