### PR TITLE
feat: add local transcriber and error handling

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/transcriber/GroqTranscriber.kt
+++ b/app/src/main/java/li/crescio/penates/diana/transcriber/GroqTranscriber.kt
@@ -1,5 +1,6 @@
 package li.crescio.penates.diana.transcriber
 
+import android.util.Log
 import li.crescio.penates.diana.notes.RawRecording
 import li.crescio.penates.diana.notes.Transcript
 import kotlinx.coroutines.Dispatchers
@@ -36,11 +37,16 @@ class GroqTranscriber(private val apiKey: String) : Transcriber {
                 .post(body)
                 .build()
 
-            client.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) throw IOException("Unexpected code $response")
-                val json = JSONObject(response.body?.string().orEmpty())
-                val text = json.optString("text", "")
-                Transcript(text)
+            try {
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) throw IOException("Unexpected code $response")
+                    val json = JSONObject(response.body?.string().orEmpty())
+                    val text = json.optString("text", "")
+                    Transcript(text)
+                }
+            } catch (e: Exception) {
+                Log.e("GroqTranscriber", "Transcription failed", e)
+                throw e
             }
         }
 }

--- a/app/src/main/java/li/crescio/penates/diana/transcriber/LocalTranscriber.kt
+++ b/app/src/main/java/li/crescio/penates/diana/transcriber/LocalTranscriber.kt
@@ -1,11 +1,68 @@
 package li.crescio.penates.diana.transcriber
 
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import li.crescio.penates.diana.notes.RawRecording
 import li.crescio.penates.diana.notes.Transcript
+import java.io.File
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
-class LocalTranscriber : Transcriber {
-    override suspend fun transcribe(recording: RawRecording): Transcript {
-        // Placeholder for on-device SpeechRecognizer usage
-        return Transcript("")
-    }
+class LocalTranscriber(private val context: Context) : Transcriber {
+    override suspend fun transcribe(recording: RawRecording): Transcript =
+        withContext(Dispatchers.Main) {
+            suspendCancellableCoroutine { cont ->
+                val audioFile = File(recording.filePath)
+                if (!audioFile.exists()) {
+                    cont.resumeWithException(IllegalArgumentException("Audio file not found"))
+                    return@suspendCancellableCoroutine
+                }
+
+                val recognizer = SpeechRecognizer.createSpeechRecognizer(context)
+                recognizer.setRecognitionListener(object : RecognitionListener {
+                    override fun onResults(results: Bundle?) {
+                        val text = results
+                            ?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+                            ?.firstOrNull()
+                            .orEmpty()
+                        cont.resume(Transcript(text))
+                        recognizer.destroy()
+                    }
+
+                    override fun onError(error: Int) {
+                        Log.e("LocalTranscriber", "Error: $error")
+                        cont.resumeWithException(RuntimeException("Speech recognition error $error"))
+                        recognizer.destroy()
+                    }
+
+                    override fun onReadyForSpeech(params: Bundle?) {}
+                    override fun onBeginningOfSpeech() {}
+                    override fun onRmsChanged(rmsdB: Float) {}
+                    override fun onBufferReceived(buffer: ByteArray?) {}
+                    override fun onEndOfSpeech() {}
+                    override fun onPartialResults(partialResults: Bundle?) {}
+                    override fun onEvent(eventType: Int, params: Bundle?) {}
+                })
+
+                val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                    putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+                    putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
+                    putExtra(RecognizerIntent.EXTRA_AUDIO_SOURCE, audioFile.absolutePath)
+                }
+
+                recognizer.startListening(intent)
+                cont.invokeOnCancellation {
+                    recognizer.cancel()
+                    recognizer.destroy()
+                }
+            }
+        }
 }

--- a/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
@@ -24,6 +24,8 @@ import li.crescio.penates.diana.BuildConfig
 import li.crescio.penates.diana.notes.Memo
 import li.crescio.penates.diana.recorder.AndroidRecorder
 import li.crescio.penates.diana.transcriber.GroqTranscriber
+import li.crescio.penates.diana.transcriber.LocalTranscriber
+import li.crescio.penates.diana.transcriber.Transcriber
 import li.crescio.penates.diana.R
 
 @Composable
@@ -36,7 +38,10 @@ fun RecorderScreen(
     val scope = rememberCoroutineScope()
 
     val recorder = remember { AndroidRecorder(context) }
-    val transcriber = remember { GroqTranscriber(BuildConfig.GROQ_API_KEY) }
+    var useLocal by remember { mutableStateOf(false) }
+    val transcriber: Transcriber = remember(useLocal) {
+        if (useLocal) LocalTranscriber(context) else GroqTranscriber(BuildConfig.GROQ_API_KEY)
+    }
 
     val logStart = stringResource(R.string.log_start_recording)
     val logStarted = stringResource(R.string.log_recording_started)
@@ -72,6 +77,22 @@ fun RecorderScreen(
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Button(onClick = {
+                useLocal = false
+                addLog("Using Groq transcriber")
+            }, enabled = useLocal) { Text("Groq") }
+            Button(onClick = {
+                useLocal = true
+                addLog("Using local transcriber")
+            }, enabled = !useLocal) { Text("Local") }
+        }
+
         Box(
             modifier = Modifier
                 .weight(1f)


### PR DESCRIPTION
## Summary
- implement on-device `LocalTranscriber` using Android `SpeechRecognizer`
- add error handling around Groq transcription network calls
- allow switching between Groq and local transcribers in `RecorderScreen`

## Testing
- `./gradlew test` *(fails: No matching client found for package name 'li.crescio.penates.diana')*

------
https://chatgpt.com/codex/tasks/task_e_68baa760c4f483259cb9d8f33284fb18