### PR TITLE
Show memo processing progress

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -75,6 +75,7 @@ fun DianaApp(repository: NoteRepository) {
             appointments = summary.appointments
             thoughts = summary.thoughts
             repository.saveSummary(summary)
+            screen = Screen.List
         }
     }
 
@@ -92,16 +93,16 @@ fun DianaApp(repository: NoteRepository) {
         Screen.Recorder -> RecorderScreen(logs, addLog = { logs.add(it) }) { memo ->
             recordedMemos.add(memo)
             logs.add(logRecorded)
+            screen = Screen.Processing
             processMemo(memo)
-            screen = Screen.List
         }
         Screen.TextMemo -> TextMemoScreen(onSave = { text ->
             val memo = Memo(text)
             logs.add(logAdded)
+            screen = Screen.Processing
             processMemo(memo)
-            screen = Screen.List
         })
-        Screen.Processing -> ProcessingScreen(processingText) { screen = Screen.List }
+        Screen.Processing -> ProcessingScreen(processingText, logs)
         Screen.Settings -> SettingsScreen()
     }
 }

--- a/app/src/main/java/li/crescio/penates/diana/ui/ProcessingScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/ProcessingScreen.kt
@@ -1,9 +1,33 @@
 package li.crescio.penates.diana.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
-fun ProcessingScreen(status: String, onDone: () -> Unit) {
-    Text(status)
+fun ProcessingScreen(status: String, messages: List<String>) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        CircularProgressIndicator()
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(status)
+        messages.forEach { message ->
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(message)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Display a processing screen with a progress indicator and status messages
- Show processing screen while memos are summarized and return to list when done

## Testing
- `./gradlew test` *(fails: build in progress, partial output)*

------
https://chatgpt.com/codex/tasks/task_e_68baaa1ca3c483258bfd5bf7ab05192e