### PR TITLE
Fix invalid escape sequence in French strings resource

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -9,7 +9,7 @@
     <string name="back">Retour</string>
     <string name="play">Lire</string>
     <string name="settings">Paramètres</string>
-    <string name="finish_recording">Terminer l\'enregistrement</string>
+    <string name="finish_recording">Terminer l'enregistrement</string>
     <string name="save">Sauvegarder</string>
     <string name="processing">Traitement…</string>
     <string name="log_recorded_memo">Mémo enregistré</string>


### PR DESCRIPTION
## Summary
- remove stray escape character from French "finish recording" string

## Testing
- `./gradlew test` *(fails: No matching client found for package name 'li.crescio.penates.diana')*


------
https://chatgpt.com/codex/tasks/task_e_68bab95abf20832596f17e92c5b22961