### PR TITLE
Release MediaPlayer after playback

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/player/AndroidPlayer.kt
+++ b/app/src/main/java/li/crescio/penates/diana/player/AndroidPlayer.kt
@@ -6,12 +6,19 @@ import android.media.MediaPlayer
 class AndroidPlayer : Player {
     override fun play(filePath: String) {
         val player = MediaPlayer()
+        var started = false
         try {
             player.setDataSource(filePath)
+            player.setOnCompletionListener { it.release() }
             player.prepare()
             player.start()
+            started = true
         } catch (e: Exception) {
             // Swallow exceptions for this simplified implementation
+        } finally {
+            if (!started) {
+                player.release()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- prevent MediaPlayer leaks by releasing on completion and in error paths

## Testing
- `./gradlew test` *(fails: No matching client found for package name 'li.crescio.penates.diana' in app/google-services.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4eaab304832588616719474fd8c0