### PR TITLE
Deduplicate notes when loading

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt
+++ b/app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt
@@ -44,7 +44,15 @@ class NoteRepository(
             emptyList()
         }
 
-        return local + remote
+        val combined = local + remote
+        return combined.distinctBy { noteKey(it) }
+    }
+
+    private fun noteKey(note: StructuredNote): String = when (note) {
+        is StructuredNote.ToDo -> "todo:${note.text}"
+        is StructuredNote.Memo -> "memo:${note.text}"
+        is StructuredNote.Event -> "event:${note.text}|${note.datetime}"
+        is StructuredNote.Free -> "free:${note.text}"
     }
 
     private fun toJson(note: StructuredNote): String {


### PR DESCRIPTION
## Summary
- remove duplicate notes by combining local and remote and filtering by content type, text and timestamp

## Testing
- `./gradlew test --no-daemon` *(fails: No matching client found for package name 'li.crescio.penates.diana')*

------
https://chatgpt.com/codex/tasks/task_e_68bd61b211b88325bce64c53793573f7