### PR TITLE
Handle network errors and timestamp stored notes

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
+++ b/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
@@ -11,11 +11,27 @@ data class Memo(
     val audioPath: String? = null
 )
 
-sealed class StructuredNote {
-    data class ToDo(val text: String) : StructuredNote()
-    data class Memo(val text: String) : StructuredNote()
-    data class Event(val text: String, val datetime: String) : StructuredNote()
-    data class Free(val text: String) : StructuredNote()
+sealed class StructuredNote(open val createdAt: Long) {
+    data class ToDo(
+        val text: String,
+        override val createdAt: Long = System.currentTimeMillis()
+    ) : StructuredNote(createdAt)
+
+    data class Memo(
+        val text: String,
+        override val createdAt: Long = System.currentTimeMillis()
+    ) : StructuredNote(createdAt)
+
+    data class Event(
+        val text: String,
+        val datetime: String,
+        override val createdAt: Long = System.currentTimeMillis()
+    ) : StructuredNote(createdAt)
+
+    data class Free(
+        val text: String,
+        override val createdAt: Long = System.currentTimeMillis()
+    ) : StructuredNote(createdAt)
 }
 
 data class NoteCollection(val notes: List<StructuredNote>)

--- a/app/src/main/java/li/crescio/penates/diana/transcriber/GroqTranscriber.kt
+++ b/app/src/main/java/li/crescio/penates/diana/transcriber/GroqTranscriber.kt
@@ -13,9 +13,14 @@ import okhttp3.RequestBody.Companion.asRequestBody
 import org.json.JSONObject
 import java.io.File
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 
 class GroqTranscriber(private val apiKey: String) : Transcriber {
-    private val client = OkHttpClient()
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .writeTimeout(60, TimeUnit.SECONDS)
+        .build()
 
     override suspend fun transcribe(recording: RawRecording): Transcript =
         withContext(Dispatchers.IO) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -19,4 +19,6 @@
     <string name="log_stop_recording">Arrêt de l\'enregistrement</string>
     <string name="log_transcription_complete">Transcription terminée</string>
     <string name="log_transcription_failed">Échec de la transcription</string>
+    <string name="log_llm_failed">Échec du traitement</string>
+    <string name="retry">Réessayer</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -19,4 +19,6 @@
     <string name="log_stop_recording">Arresto registrazione</string>
     <string name="log_transcription_complete">Trascrizione completata</string>
     <string name="log_transcription_failed">Trascrizione fallita</string>
+    <string name="log_llm_failed">Elaborazione fallita</string>
+    <string name="retry">Riprova</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,6 @@
     <string name="log_stop_recording">Stopping recording</string>
     <string name="log_transcription_complete">Transcription complete</string>
     <string name="log_transcription_failed">Transcription failed</string>
+    <string name="log_llm_failed">Processing failed</string>
+    <string name="retry">Retry</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add explicit OkHttp timeouts for LLM and transcription clients
- Surface retryable snackbars for transcription and LLM processing failures
- Timestamp notes on save and show them in recent-first order

## Testing
- `./gradlew test` *(fails: No matching client found for package name 'li.crescio.penates.diana' in google-services.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bda2947ac48325a95a0eb42e2217e5