### PR TITLE
Add MemoProcessor test with MockWebServer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'io.mockk:mockk:1.12.3'
     testImplementation 'org.json:json:20210307'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"

--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -2,31 +2,36 @@ package li.crescio.penates.diana.llm
 
 import li.crescio.penates.diana.notes.Memo
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONArray
 import org.json.JSONObject
+import java.io.IOException
 import java.util.Locale
 import java.util.concurrent.TimeUnit
-import java.io.IOException
 import kotlin.collections.ArrayDeque
 
 /**
  * Maintains running text buffers for to-dos, appointments and free-form
  * thoughts, updating each by calling an LLM with strict structured outputs.
  */
-class MemoProcessor(private val apiKey: String, private val logger: LlmLogger, locale: Locale) {
-    private val client = OkHttpClient.Builder()
+class MemoProcessor(
+    private val apiKey: String,
+    private val logger: LlmLogger,
+    locale: Locale,
+    private val baseUrl: String = "https://openrouter.ai/api/v1/chat/completions",
+    private val client: OkHttpClient = OkHttpClient.Builder()
         .connectTimeout(30, TimeUnit.SECONDS)
         .readTimeout(60, TimeUnit.SECONDS)
         .writeTimeout(60, TimeUnit.SECONDS)
         .build()
+) {
 
     private var todo: String = ""
     private var appointments: String = ""
@@ -70,7 +75,7 @@ class MemoProcessor(private val apiKey: String, private val logger: LlmLogger, l
 
         val requestBody = json.toRequestBody("application/json".toMediaType())
         val request = Request.Builder()
-            .url("https://openrouter.ai/api/v1/chat/completions")
+            .url(baseUrl)
             .header("Authorization", "Bearer $apiKey")
             .post(requestBody)
             .build()

--- a/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
@@ -1,0 +1,51 @@
+package li.crescio.penates.diana.llm
+
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import li.crescio.penates.diana.notes.Memo
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Locale
+
+class MemoProcessorTest {
+    @Test
+    fun process_updatesSummaries_andLogs() = runBlocking {
+        System.setProperty("net.bytebuddy.experimental", "true")
+
+        val server = MockWebServer()
+        fun completion(updated: String): String {
+            val message = JSONObject().put("content", "{\"updated\":\"$updated\"}")
+            val choice = JSONObject().put("message", message)
+            val choices = JSONArray().put(choice)
+            return JSONObject().put("choices", choices).toString()
+        }
+        server.enqueue(MockResponse().setBody(completion("todo updated")).setResponseCode(200))
+        server.enqueue(MockResponse().setBody(completion("appointments updated")).setResponseCode(200))
+        server.enqueue(MockResponse().setBody(completion("thoughts updated")).setResponseCode(200))
+        server.start()
+
+        val logger = mockk<LlmLogger>(relaxed = true)
+        val processor = MemoProcessor(
+            apiKey = "key",
+            logger = logger,
+            locale = Locale.ENGLISH,
+            baseUrl = server.url("/").toString(),
+            client = OkHttpClient()
+        )
+
+        val summary = processor.process(Memo("sample"))
+
+        assertEquals("todo updated", summary.todo)
+        assertEquals("appointments updated", summary.appointments)
+        assertEquals("thoughts updated", summary.thoughts)
+        verify(exactly = 3) { logger.log(any(), any()) }
+
+        server.shutdown()
+    }
+}


### PR DESCRIPTION
## Summary
- Allow overriding the completion endpoint and HTTP client in MemoProcessor
- Add MockWebServer dependency for unit tests
- Test MemoProcessor process() with a MockWebServer and verify logger usage

## Testing
- `./gradlew :app:testDebugUnitTest --tests li.crescio.penates.diana.llm.MemoProcessorTest --info`


------
https://chatgpt.com/codex/tasks/task_e_68bdd780a8088325a7b4ac239926cc4a