### PR TITLE
test: cover error responses in MemoProcessor

### DIFF
--- a/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
@@ -10,7 +10,9 @@ import okhttp3.mockwebserver.MockWebServer
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import org.junit.Test
+import java.io.IOException
 import java.util.Locale
 
 class MemoProcessorTest {
@@ -45,6 +47,129 @@ class MemoProcessorTest {
         assertEquals("appointments updated", summary.appointments)
         assertEquals("thoughts updated", summary.thoughts)
         verify(exactly = 3) { logger.log(any(), any()) }
+
+        server.shutdown()
+    }
+
+    @Test
+    fun process_non2xxStatus_throwsIOException() = runBlocking {
+        System.setProperty("net.bytebuddy.experimental", "true")
+
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setResponseCode(500).setBody("error"))
+        server.start()
+
+        val processor = MemoProcessor(
+            apiKey = "key",
+            logger = mockk(relaxed = true),
+            locale = Locale.ENGLISH,
+            baseUrl = server.url("/").toString(),
+            client = OkHttpClient()
+        )
+
+        try {
+            processor.process(Memo("sample"))
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            assertEquals("HTTP 500 Server Error", e.message)
+        }
+
+        server.shutdown()
+    }
+
+    @Test
+    fun process_blankContent_throwsIOException() = runBlocking {
+        System.setProperty("net.bytebuddy.experimental", "true")
+
+        val server = MockWebServer()
+        fun completion(content: String): String {
+            val message = JSONObject().put("content", content)
+            val choice = JSONObject().put("message", message)
+            val choices = JSONArray().put(choice)
+            return JSONObject().put("choices", choices).toString()
+        }
+        server.enqueue(MockResponse().setBody(completion(""))
+            .setResponseCode(200))
+        server.start()
+
+        val processor = MemoProcessor(
+            apiKey = "key",
+            logger = mockk(relaxed = true),
+            locale = Locale.ENGLISH,
+            baseUrl = server.url("/").toString(),
+            client = OkHttpClient()
+        )
+
+        try {
+            processor.process(Memo("sample"))
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            assertEquals("Blank content", e.message)
+        }
+
+        server.shutdown()
+    }
+
+    @Test
+    fun process_missingJson_throwsIOException() = runBlocking {
+        System.setProperty("net.bytebuddy.experimental", "true")
+
+        val server = MockWebServer()
+        fun completion(content: String): String {
+            val message = JSONObject().put("content", content)
+            val choice = JSONObject().put("message", message)
+            val choices = JSONArray().put(choice)
+            return JSONObject().put("choices", choices).toString()
+        }
+        server.enqueue(MockResponse().setBody(completion("plain text")).setResponseCode(200))
+        server.start()
+
+        val processor = MemoProcessor(
+            apiKey = "key",
+            logger = mockk(relaxed = true),
+            locale = Locale.ENGLISH,
+            baseUrl = server.url("/").toString(),
+            client = OkHttpClient()
+        )
+
+        try {
+            processor.process(Memo("sample"))
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            assertEquals("No JSON found", e.message)
+        }
+
+        server.shutdown()
+    }
+
+    @Test
+    fun process_invalidJson_throwsIOException() = runBlocking {
+        System.setProperty("net.bytebuddy.experimental", "true")
+
+        val server = MockWebServer()
+        fun completion(content: String): String {
+            val message = JSONObject().put("content", content)
+            val choice = JSONObject().put("message", message)
+            val choices = JSONArray().put(choice)
+            return JSONObject().put("choices", choices).toString()
+        }
+        server.enqueue(MockResponse().setBody(completion("{invalid}")).setResponseCode(200))
+        server.start()
+
+        val processor = MemoProcessor(
+            apiKey = "key",
+            logger = mockk(relaxed = true),
+            locale = Locale.ENGLISH,
+            baseUrl = server.url("/").toString(),
+            client = OkHttpClient()
+        )
+
+        try {
+            processor.process(Memo("sample"))
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            assertEquals("Invalid JSON", e.message)
+        }
 
         server.shutdown()
     }


### PR DESCRIPTION
## Summary
- add tests for MemoProcessor error scenarios
- verify IOException is thrown for HTTP errors, blank content, missing or invalid JSON

## Testing
- `./gradlew :app:testDebugUnitTest --tests li.crescio.penates.diana.llm.MemoProcessorTest`


------
https://chatgpt.com/codex/tasks/task_e_68bde07187088325b38087dad0c6f9fa