### PR TITLE
Add test double to verify MediaRecorder cleanup

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/recorder/AndroidRecorder.kt
+++ b/app/src/main/java/li/crescio/penates/diana/recorder/AndroidRecorder.kt
@@ -9,7 +9,10 @@ import li.crescio.penates.diana.notes.RawRecording
 import java.io.File
 
 /** Records audio from the device microphone and stores it in a temporary file. */
-class AndroidRecorder(private val context: Context) : Recorder {
+class AndroidRecorder(
+    private val context: Context,
+    private val recorderFactory: () -> MediaRecorder = { MediaRecorder() },
+) : Recorder {
     private var recorder: MediaRecorder? = null
     private var outputFile: File? = null
 
@@ -34,7 +37,7 @@ class AndroidRecorder(private val context: Context) : Recorder {
         val file = File.createTempFile("rec_", ".m4a", outputDir)
         outputFile = file
 
-        val newRecorder = MediaRecorder().apply {
+        val newRecorder = recorderFactory().apply {
             setAudioSource(MediaRecorder.AudioSource.MIC)
             setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
             setAudioEncoder(MediaRecorder.AudioEncoder.AAC)

--- a/app/src/test/java/li/crescio/penates/diana/recorder/AndroidRecorderTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/recorder/AndroidRecorderTest.kt
@@ -1,0 +1,51 @@
+package li.crescio.penates.diana.recorder
+
+import android.content.Context
+import android.media.MediaRecorder
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private class TestMediaRecorder(private val id: Int, private val log: MutableList<String>) : MediaRecorder() {
+    override fun setAudioSource(source: Int) {}
+    override fun setOutputFormat(format: Int) {}
+    override fun setAudioEncoder(encoder: Int) {}
+    override fun setAudioEncodingBitRate(bitRate: Int) {}
+    override fun setAudioSamplingRate(rate: Int) {}
+    override fun setOutputFile(path: String?) {}
+    override fun prepare() { log += "prepare-$id" }
+    override fun start() { log += "start-$id" }
+    override fun stop() {}
+    override fun reset() { log += "reset-$id" }
+    override fun release() { log += "release-$id" }
+}
+
+class AndroidRecorderTest {
+    @Test
+    fun startTwice_releasesPreviousRecorder() = runBlocking {
+        val log = mutableListOf<String>()
+        var nextId = 0
+        val context = mockk<Context>()
+        val cacheDir = createTempDir().also { it.deleteOnExit() }
+        every { context.cacheDir } returns cacheDir
+
+        val recorder = AndroidRecorder(context) {
+            TestMediaRecorder(nextId++, log)
+        }
+
+        recorder.start()
+        recorder.start()
+
+        val resetIndex = log.indexOf("reset-0")
+        val releaseIndex = log.indexOf("release-0")
+        val secondStartIndex = log.indexOf("start-1")
+
+        assertTrue(resetIndex >= 0)
+        assertTrue(releaseIndex >= 0)
+        assertTrue(secondStartIndex >= 0)
+        assertTrue(resetIndex < secondStartIndex)
+        assertTrue(releaseIndex < secondStartIndex)
+    }
+}


### PR DESCRIPTION
## Summary
- allow injecting a MediaRecorder factory for AndroidRecorder
- add unit test using a fake MediaRecorder to ensure previous recorder resets and releases before restarting

## Testing
- `./gradlew :app:testDebugUnitTest --tests li.crescio.penates.diana.recorder.AndroidRecorderTest --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68bdf7eeeee483258b77930f297d86dd