### PR TITLE
Inject MediaPlayer factory and add release test

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/player/AndroidPlayer.kt
+++ b/app/src/main/java/li/crescio/penates/diana/player/AndroidPlayer.kt
@@ -3,9 +3,11 @@ package li.crescio.penates.diana.player
 import android.media.MediaPlayer
 
 /** Plays audio files using [MediaPlayer]. */
-class AndroidPlayer : Player {
+class AndroidPlayer(
+    private val mediaPlayerFactory: () -> MediaPlayer = { MediaPlayer() }
+) : Player {
     override fun play(filePath: String) {
-        val player = MediaPlayer()
+        val player = mediaPlayerFactory()
         var started = false
         try {
             player.setDataSource(filePath)

--- a/app/src/test/java/li/crescio/penates/diana/player/AndroidPlayerTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/player/AndroidPlayerTest.kt
@@ -1,0 +1,21 @@
+package li.crescio.penates.diana.player
+
+import android.media.MediaPlayer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class AndroidPlayerTest {
+    @Test
+    fun release_is_called_when_setDataSource_throws() {
+        val mediaPlayer = mockk<MediaPlayer>(relaxed = true)
+        every { mediaPlayer.setDataSource(any<String>()) } throws RuntimeException("boom")
+
+        val player = AndroidPlayer(mediaPlayerFactory = { mediaPlayer })
+
+        player.play("file")
+
+        verify { mediaPlayer.release() }
+    }
+}


### PR DESCRIPTION
## Summary
- allow AndroidPlayer to accept a MediaPlayer factory for dependency injection
- add unit test ensuring MediaPlayer.release() is called when setDataSource throws

## Testing
- `./gradlew testDebugUnitTest --tests li.crescio.penates.diana.player.AndroidPlayerTest --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68bed12f502083259e89b6574c87e09d