### PR TITLE
Log errors when memo processing fails

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -1,6 +1,7 @@
 package li.crescio.penates.diana
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.*
@@ -92,6 +93,8 @@ fun DianaApp(repository: NoteRepository) {
                 repository.saveSummary(summary)
                 screen = Screen.List
             } catch (e: Exception) {
+                Log.e("DianaApp", "Error processing memo: ${'$'}{e.message}", e)
+                addLog("LLM error: ${'$'}{e.message ?: e.toString()}")
                 val result = snackbarHostState.showSnackbar(
                     message = logLlmFailed,
                     actionLabel = retryLabel


### PR DESCRIPTION
## Summary
- log memo processing failures with Log.e including message and stack trace
- append LLM error messages to in-app log list for user debugging

## Testing
- `./gradlew test` *(fails: warning and long runtime; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bf415b26148325a81caa02bcb70b33