### PR TITLE
Check OpenRouter API key before memo processing

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -84,6 +84,7 @@ fun DianaApp(repository: NoteRepository) {
     val processingText = stringResource(R.string.processing)
     val logLlmFailed = stringResource(R.string.log_llm_failed)
     val retryLabel = stringResource(R.string.retry)
+    val logApiKeyMissing = stringResource(R.string.api_key_missing)
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(logger) {
@@ -107,6 +108,14 @@ fun DianaApp(repository: NoteRepository) {
     }
 
     fun processMemo(memo: Memo) {
+        if (BuildConfig.OPENROUTER_API_KEY.isBlank()) {
+            addLog(logApiKeyMissing)
+            scope.launch {
+                snackbarHostState.showSnackbar(logApiKeyMissing)
+                screen = Screen.List
+            }
+            return
+        }
         scope.launch {
             try {
                 val summary = processor.process(memo)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="log_transcription_failed">Transcription failed</string>
     <string name="log_llm_failed">Processing failed</string>
     <string name="retry">Retry</string>
+    <string name="api_key_missing">OpenRouter API key missing. Memo processing disabled.</string>
 </resources>

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -26,6 +26,6 @@ group.
 ## Local builds
 
 1. Install JDK 17 and the Android SDK.
-2. Set environment variables for `GROQ_API_KEY` and `OPENROUTER_API_KEY`.
+2. Provide `GROQ_API_KEY` and `OPENROUTER_API_KEY` either as environment variables or in `local.properties` (e.g. `OPENROUTER_API_KEY=your_key`). If `OPENROUTER_API_KEY` is empty, memo processing is disabled.
 3. Open the project in Android Studio and let Gradle sync.
 4. Run `./gradlew assembleDebug` to build and install on a device.


### PR DESCRIPTION
## Summary
- Guard memo processing against missing `OPENROUTER_API_KEY` and show a snackbar when the key is absent
- Document how to provide `OPENROUTER_API_KEY` for local builds

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: command did not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68c0161cf8988325916bada6ecb5dfd0