### PR TITLE
Refine error logs in memo processing

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -133,8 +133,8 @@ fun DianaApp(repository: NoteRepository) {
                 repository.saveSummary(summary)
                 screen = Screen.List
             } catch (e: Exception) {
-                Log.e("DianaApp", "Error processing memo: ${'$'}{e.message}", e)
-                addLog("LLM error: ${'$'}{e.message ?: e.toString()}")
+                Log.e("DianaApp", "Error processing memo: ${e.message}", e)
+                addLog("LLM error: ${e.message ?: e}")
                 val result = snackbarHostState.showSnackbar(
                     message = logLlmFailed,
                     actionLabel = retryLabel


### PR DESCRIPTION
## Summary
- Remove unnecessary string templates in MainActivity logging
- Simplify LLM error logging

## Testing
- `./gradlew test --console=plain` *(failed: test task hung and did not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c192d5b2e48325b848ddbe72ba31ee