### PR TITLE
ci: run build only on tags or manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
+---
 name: Android CI
 
-on:
+'on':
   push:
-    branches: [ main ]
+    tags:
+      - '*'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- run CI workflow only for git tags or manual dispatch
- keep build step and Firebase App Distribution as before

## Testing
- `yamllint .github/workflows/ci.yml`
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_68c19f118bd083258623c0e29d1c5ae1