### PR TITLE
Display LLM API messages in UI log

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/LogSection.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/LogSection.kt
@@ -1,0 +1,44 @@
+package li.crescio.penates.diana.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LogSection(logs: List<String>) {
+    val listState = rememberLazyListState()
+    LaunchedEffect(logs.size) {
+        if (logs.isNotEmpty()) {
+            listState.scrollToItem(logs.lastIndex)
+        }
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(120.dp)
+            .background(Color.Black)
+    ) {
+        LazyColumn(state = listState, modifier = Modifier.padding(8.dp)) {
+            items(logs) { log ->
+                Text(
+                    log,
+                    fontFamily = FontFamily.Monospace,
+                    color = Color.Green
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -1,17 +1,12 @@
 package li.crescio.penates.diana.ui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import li.crescio.penates.diana.R
@@ -26,12 +21,6 @@ fun NotesListScreen(
     onAddMemo: () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
-        val listState = rememberLazyListState()
-        LaunchedEffect(logs.size) {
-            if (logs.isNotEmpty()) {
-                listState.scrollToItem(logs.lastIndex)
-            }
-        }
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -64,21 +53,6 @@ fun NotesListScreen(
             }
         }
 
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(120.dp)
-                .background(Color.Black)
-        ) {
-            LazyColumn(state = listState, modifier = Modifier.padding(8.dp)) {
-                items(logs) { log ->
-                    Text(
-                        log,
-                        fontFamily = FontFamily.Monospace,
-                        color = Color.Green
-                    )
-                }
-            }
-        }
+        LogSection(logs)
     }
 }

--- a/app/src/main/java/li/crescio/penates/diana/ui/ProcessingScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/ProcessingScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
@@ -15,19 +16,19 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun ProcessingScreen(status: String, messages: List<String>) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        CircularProgressIndicator()
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(status)
-        messages.forEach { message ->
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(message)
+    Column(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            CircularProgressIndicator()
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(status)
         }
+        LogSection(messages)
     }
 }

--- a/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
@@ -4,11 +4,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.SnackbarHostState
@@ -16,9 +12,7 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import androidx.core.content.ContextCompat
@@ -78,12 +72,6 @@ fun RecorderScreen(
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
-        val listState = rememberLazyListState()
-        LaunchedEffect(logs.size) {
-            if (logs.isNotEmpty()) {
-                listState.scrollToItem(logs.lastIndex)
-            }
-        }
         Box(
             modifier = Modifier
                 .weight(1f)
@@ -118,21 +106,6 @@ fun RecorderScreen(
             ) { Text(stringResource(R.string.finish_recording)) }
         }
 
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(120.dp)
-                .background(Color.Black)
-        ) {
-            LazyColumn(state = listState, modifier = Modifier.padding(8.dp)) {
-                items(logs) { log ->
-                    Text(
-                        log,
-                        fontFamily = FontFamily.Monospace,
-                        color = Color.Green
-                    )
-                }
-            }
-        }
+        LogSection(logs)
     }
 }


### PR DESCRIPTION
## Summary
- Extract a reusable `LogSection` composable to show messages with autoscroll
- Use `LogSection` across screens and add it to Processing screen so LLM API traffic appears in the UI log

## Testing
- ⚠️ `./gradlew test` (terminated without completing; see tail of log for last executed tasks)

------
https://chatgpt.com/codex/tasks/task_e_68c1ba82ecf08325a9ea0bb8d164f3d3