### PR TITLE
Log LLM request and response pairs

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -17,6 +17,7 @@ import java.io.IOException
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.collections.ArrayDeque
+import android.util.Log
 
 /**
  * Maintains running text buffers for to-dos, appointments and free-form
@@ -149,8 +150,13 @@ class LlmLogger(private val maxLogs: Int = 100) {
     private val _logFlow = MutableSharedFlow<String>()
     val logFlow: SharedFlow<String> = _logFlow.asSharedFlow()
 
+    companion object {
+        private const val TAG = "LlmLogger"
+    }
+
     fun log(request: String, response: String) {
         val entry = "REQUEST: $request\nRESPONSE: $response"
+        Log.d(TAG, entry)
         if (logs.size == maxLogs) {
             logs.removeFirst()
         }


### PR DESCRIPTION
## Summary
- Add `android.util.Log` logging in `LlmLogger` to emit request/response pairs
- Use consistent `LlmLogger` tag for easy logcat filtering

## Testing
- `./gradlew test` *(fails: command was interrupted due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e9a201a0832598ad11a783331327