### PR TITLE
feat: structure todo items with status and tags

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
+++ b/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
@@ -14,6 +14,8 @@ data class Memo(
 sealed class StructuredNote(open val createdAt: Long) {
     data class ToDo(
         val text: String,
+        val status: String = "",
+        val tags: List<String> = emptyList(),
         override val createdAt: Long = System.currentTimeMillis()
     ) : StructuredNote(createdAt)
 

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -2,17 +2,17 @@ package li.crescio.penates.diana.ui
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import li.crescio.penates.diana.R
+import li.crescio.penates.diana.llm.TodoItem
 @Composable
 fun NotesListScreen(
-    todo: String,
+    todoItems: List<TodoItem>,
     appointments: String,
     thoughts: String,
     logs: List<String>,
@@ -41,7 +41,28 @@ fun NotesListScreen(
         ) {
             item {
                 Text(stringResource(R.string.todo_list))
-                Text(todo, modifier = Modifier.padding(bottom = 16.dp))
+                Column(modifier = Modifier.padding(bottom = 16.dp)) {
+                    todoItems.forEach { item ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(vertical = 4.dp)
+                        ) {
+                            Checkbox(checked = item.status == "done", onCheckedChange = null)
+                            Column(modifier = Modifier.padding(start = 8.dp)) {
+                                Text(item.text)
+                                Row {
+                                    item.tags.forEach { tag ->
+                                        AssistChip(
+                                            onClick = {},
+                                            label = { Text(tag) },
+                                            modifier = Modifier.padding(end = 4.dp)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
             item {
                 Text(stringResource(R.string.appointments))

--- a/app/src/test/java/li/crescio/penates/diana/llm/LlmLoggerTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/llm/LlmLoggerTest.kt
@@ -5,12 +5,18 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
+import io.mockk.every
+import io.mockk.mockkStatic
+import android.util.Log
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class LlmLoggerTest {
     @Test
     fun log_keepsLatestEntries_andEmitsThroughFlow() = runBlocking {
+        System.setProperty("net.bytebuddy.experimental", "true")
+        mockkStatic(Log::class)
+        every { Log.d(any(), any()) } returns 0
         val logger = LlmLogger(maxLogs = 2)
         val emitted = mutableListOf<String>()
         val job = launch {


### PR DESCRIPTION
## Summary
- extend LLM memo processor to handle structured todo items with status and tags
- persist todo item status/tag fields and render them as checkbox list with tag chips
- update models, repository, and tests for structured todo data

## Testing
- `./gradlew :app:testDebugUnitTest --tests NoteRepositoryTest.saveNotes_writesJsonLines_andAddsToFirestore`
- `./gradlew :app:testDebugUnitTest --tests NoteRepositoryTest.summaryToNotes_splitsAndTrimsMultilineText`


------
https://chatgpt.com/codex/tasks/task_e_68c2bd5d6cbc83258bffc2ea8c7b40ca