### PR TITLE
Support structured appointments with location

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
+++ b/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
@@ -27,6 +27,7 @@ sealed class StructuredNote(open val createdAt: Long) {
     data class Event(
         val text: String,
         val datetime: String,
+        val location: String = "",
         override val createdAt: Long = System.currentTimeMillis()
     ) : StructuredNote(createdAt)
 

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -10,10 +10,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import li.crescio.penates.diana.R
 import li.crescio.penates.diana.llm.TodoItem
+import li.crescio.penates.diana.llm.Appointment
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
 @Composable
 fun NotesListScreen(
     todoItems: List<TodoItem>,
-    appointments: String,
+    appointments: List<Appointment>,
     thoughts: String,
     logs: List<String>,
     onRecord: () -> Unit,
@@ -66,7 +69,16 @@ fun NotesListScreen(
             }
             item {
                 Text(stringResource(R.string.appointments))
-                Text(appointments, modifier = Modifier.padding(bottom = 16.dp))
+                Column(modifier = Modifier.padding(bottom = 16.dp)) {
+                    appointments.sortedBy { it.datetime }.forEach { appt ->
+                        val formatted = runCatching {
+                            OffsetDateTime.parse(appt.datetime)
+                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+                        }.getOrElse { appt.datetime }
+                        val location = if (appt.location.isNotBlank()) " @ ${appt.location}" else ""
+                        Text("$formatted ${appt.text}$location")
+                    }
+                }
             }
             item {
                 Text(stringResource(R.string.thoughts_notes))

--- a/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
@@ -47,6 +47,7 @@ class MemoProcessorTest {
         assertEquals("todo updated", summary.todo)
         assertEquals("appointments updated", summary.appointments)
         assertEquals("thoughts updated", summary.thoughts)
+        assertTrue(summary.appointmentItems.isEmpty())
         verify(exactly = 3) { logger.log(any(), any()) }
 
         server.shutdown()


### PR DESCRIPTION
## Summary
- Parse appointments with text, datetime, and optional location in `MemoProcessor`, exposing an `Appointment` model
- Persist and load appointments with datetime and location via `StructuredNote.Event` and `NoteRepository`
- Render appointments chronologically in the notes list with formatted dates and locations

## Testing
- `./gradlew test --console=plain > /tmp/unit.log 2>&1` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cddbb8d88325a8a830d9a006222b