### PR TITLE
Support tagged thoughts throughout notes

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -87,7 +87,7 @@ fun DianaApp(repository: NoteRepository) {
     var todo by remember { mutableStateOf("") }
     var todoItems by remember { mutableStateOf(listOf<TodoItem>()) }
     var appointments by remember { mutableStateOf(listOf<Appointment>()) }
-    var thoughts by remember { mutableStateOf("") }
+    var thoughtNotes by remember { mutableStateOf(listOf<StructuredNote>()) }
     val scope = rememberCoroutineScope()
     val processor = remember { MemoProcessor(BuildConfig.OPENROUTER_API_KEY, logger, Locale.getDefault()) }
     val player: Player = remember { AndroidPlayer() }
@@ -110,14 +110,7 @@ fun DianaApp(repository: NoteRepository) {
         appointments = notes.filterIsInstance<StructuredNote.Event>().map {
             Appointment(it.text, it.datetime, it.location)
         }
-        thoughts = notes.filter { it is StructuredNote.Memo || it is StructuredNote.Free }
-            .joinToString("\n") {
-                when (it) {
-                    is StructuredNote.Memo -> it.text
-                    is StructuredNote.Free -> it.text
-                    else -> ""
-                }
-            }
+        thoughtNotes = notes.filter { it is StructuredNote.Memo || it is StructuredNote.Free }
     }
 
     fun processMemo(memo: Memo) {
@@ -135,7 +128,7 @@ fun DianaApp(repository: NoteRepository) {
                 todo = summary.todo
                 todoItems = summary.todoItems
                 appointments = summary.appointmentItems
-                thoughts = summary.thoughts
+                thoughtNotes = summary.thoughtItems.map { StructuredNote.Memo(it.text, it.tags) }
                 repository.saveSummary(summary)
                 screen = Screen.List
             } catch (e: IOException) {
@@ -164,7 +157,7 @@ fun DianaApp(repository: NoteRepository) {
             Screen.List -> NotesListScreen(
                 todoItems,
                 appointments,
-                thoughts,
+                thoughtNotes,
                 logs,
                 onRecord = { screen = Screen.Recorder },
                 onViewRecordings = { screen = Screen.Recordings },

--- a/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
+++ b/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
@@ -21,6 +21,7 @@ sealed class StructuredNote(open val createdAt: Long) {
 
     data class Memo(
         val text: String,
+        val tags: List<String> = emptyList(),
         override val createdAt: Long = System.currentTimeMillis()
     ) : StructuredNote(createdAt)
 
@@ -33,6 +34,7 @@ sealed class StructuredNote(open val createdAt: Long) {
 
     data class Free(
         val text: String,
+        val tags: List<String> = emptyList(),
         override val createdAt: Long = System.currentTimeMillis()
     ) : StructuredNote(createdAt)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="todo_list">To-Do List</string>
     <string name="appointments">Appointments</string>
     <string name="thoughts_notes">Thoughts &amp; Notes</string>
+    <string name="filter_tag">Filter by tag</string>
     <string name="back">Back</string>
     <string name="play">Play</string>
     <string name="settings">Settings</string>


### PR DESCRIPTION
## Summary
- Parse LLM "thoughts" responses into structured `Thought` items with tags
- Allow `StructuredNote.Memo` and `Free` to store tags and persist them in `NoteRepository`
- Render tagged notes with tag filter in `NotesListScreen`

## Testing
- `⚠️ ./gradlew test` *(incomplete due to environment timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c32635938c83258ea5ad64a6d21514