### PR TITLE
Use FlowRow for responsive action bar

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -1,5 +1,6 @@
 package li.crescio.penates.diana.ui
 
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.*
@@ -14,6 +15,7 @@ import li.crescio.penates.diana.llm.Appointment
 import li.crescio.penates.diana.notes.StructuredNote
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun NotesListScreen(
     todoItems: List<TodoItem>,
@@ -26,18 +28,16 @@ fun NotesListScreen(
     onSettings: () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
-        Row(
+        FlowRow(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 16.dp),
-            horizontalArrangement = Arrangement.Center
+            horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Button(onClick = onRecord) { Text(stringResource(R.string.record)) }
-            Spacer(modifier = Modifier.width(16.dp))
             Button(onClick = onAddMemo) { Text(stringResource(R.string.text_memo)) }
-            Spacer(modifier = Modifier.width(16.dp))
             Button(onClick = onViewRecordings) { Text(stringResource(R.string.view_recordings)) }
-            Spacer(modifier = Modifier.width(16.dp))
             Button(onClick = onSettings) { Text(stringResource(R.string.settings)) }
         }
 


### PR DESCRIPTION
## Summary
- make NotesListScreen action buttons responsive by switching to FlowRow
- opt in to ExperimentalLayoutApi for FlowRow usage

## Testing
- `./gradlew test` *(fails: command did not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c4926554208325986b0de0faea3a29