### PR TITLE
Persist todo checkbox changes and tidy list layout

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -162,7 +162,22 @@ fun DianaApp(repository: NoteRepository) {
                 onRecord = { screen = Screen.Recorder },
                 onViewRecordings = { screen = Screen.Recordings },
                 onAddMemo = { screen = Screen.TextMemo },
-                onSettings = { screen = Screen.Settings }
+                onSettings = { screen = Screen.Settings },
+                onTodoCheckedChange = { item, checked ->
+                    val newStatus = if (checked) "done" else "open"
+                    todoItems = todoItems.map {
+                        if (it.text == item.text) it.copy(status = newStatus) else it
+                    }
+                    scope.launch {
+                        val todoNotes = todoItems.map {
+                            StructuredNote.ToDo(it.text, it.status, it.tags)
+                        }
+                        val apptNotes = appointments.map {
+                            StructuredNote.Event(it.text, it.datetime, it.location)
+                        }
+                        repository.saveNotes(todoNotes + apptNotes + thoughtNotes)
+                    }
+                }
             )
             Screen.Recordings -> RecordedMemosScreen(recordedMemos, player) { screen = Screen.List }
             Screen.Recorder -> RecorderScreen(

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -26,6 +26,7 @@ fun NotesListScreen(
     onViewRecordings: () -> Unit,
     onAddMemo: () -> Unit,
     onSettings: () -> Unit,
+    onTodoCheckedChange: (TodoItem, Boolean) -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         FlowRow(
@@ -50,20 +51,37 @@ fun NotesListScreen(
                 Text(stringResource(R.string.todo_list))
                 Column(modifier = Modifier.padding(bottom = 16.dp)) {
                     todoItems.forEach { item ->
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(vertical = 4.dp)
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp)
                         ) {
-                            Checkbox(checked = item.status == "done", onCheckedChange = null)
-                            Column(modifier = Modifier.padding(start = 8.dp)) {
-                                Text(item.text)
-                                Row {
-                                    item.tags.forEach { tag ->
-                                        AssistChip(
-                                            onClick = {},
-                                            label = { Text(tag) },
-                                            modifier = Modifier.padding(end = 4.dp)
-                                        )
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(8.dp)
+                            ) {
+                                Checkbox(
+                                    checked = item.status == "done",
+                                    onCheckedChange = { checked ->
+                                        onTodoCheckedChange(item, checked)
+                                    }
+                                )
+                                Column(
+                                    modifier = Modifier
+                                        .padding(start = 8.dp)
+                                        .weight(1f)
+                                ) {
+                                    Text(item.text)
+                                    Row {
+                                        item.tags.forEach { tag ->
+                                            AssistChip(
+                                                onClick = {},
+                                                label = { Text(tag) },
+                                                modifier = Modifier.padding(end = 4.dp)
+                                            )
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- Update `NotesListScreen` to handle checkbox toggles via `onTodoCheckedChange`
- Persist todo status updates through `NoteRepository`
- Wrap todo rows in `Card` for better layout and long text wrapping

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c49e2d4c2083258ef8b71b36633e4b