### PR TITLE
Add navigation bar for memo actions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.activity:activity-compose:1.8.2'
     implementation "androidx.compose.ui:ui:$compose_ui_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_ui_version"
     implementation "androidx.compose.material3:material3:1.2.1"
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'

--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -10,7 +10,18 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.LibraryMusic
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.foundation.layout.padding
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
@@ -152,17 +163,66 @@ fun DianaApp(repository: NoteRepository) {
         }
     }
 
-    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) {
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        bottomBar = {
+            if (screen == Screen.List) {
+                NavigationBar {
+                    NavigationBarItem(
+                        selected = false,
+                        onClick = { screen = Screen.Recorder },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Filled.Mic,
+                                contentDescription = stringResource(R.string.record)
+                            )
+                        },
+                        label = { Text(stringResource(R.string.record)) }
+                    )
+                    NavigationBarItem(
+                        selected = false,
+                        onClick = { screen = Screen.TextMemo },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Filled.Edit,
+                                contentDescription = stringResource(R.string.text_memo)
+                            )
+                        },
+                        label = { Text(stringResource(R.string.text_memo)) }
+                    )
+                    NavigationBarItem(
+                        selected = false,
+                        onClick = { screen = Screen.Recordings },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Filled.LibraryMusic,
+                                contentDescription = stringResource(R.string.view_recordings)
+                            )
+                        },
+                        label = { Text(stringResource(R.string.view_recordings)) }
+                    )
+                    NavigationBarItem(
+                        selected = false,
+                        onClick = { screen = Screen.Settings },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Filled.Settings,
+                                contentDescription = stringResource(R.string.settings)
+                            )
+                        },
+                        label = { Text(stringResource(R.string.settings)) }
+                    )
+                }
+            }
+        }
+    ) { innerPadding ->
         when (screen) {
             Screen.List -> NotesListScreen(
                 todoItems,
                 appointments,
                 thoughtNotes,
                 logs,
-                onRecord = { screen = Screen.Recorder },
-                onViewRecordings = { screen = Screen.Recordings },
-                onAddMemo = { screen = Screen.TextMemo },
-                onSettings = { screen = Screen.Settings },
+                modifier = Modifier.padding(innerPadding),
                 onTodoCheckedChange = { item, checked ->
                     val newStatus = if (checked) "done" else "open"
                     todoItems = todoItems.map {

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -1,6 +1,5 @@
 package li.crescio.penates.diana.ui
 
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.*
@@ -15,33 +14,17 @@ import li.crescio.penates.diana.llm.Appointment
 import li.crescio.penates.diana.notes.StructuredNote
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
-@OptIn(ExperimentalLayoutApi::class)
+
 @Composable
 fun NotesListScreen(
     todoItems: List<TodoItem>,
     appointments: List<Appointment>,
     notes: List<StructuredNote>,
     logs: List<String>,
-    onRecord: () -> Unit,
-    onViewRecordings: () -> Unit,
-    onAddMemo: () -> Unit,
-    onSettings: () -> Unit,
+    modifier: Modifier = Modifier,
     onTodoCheckedChange: (TodoItem, Boolean) -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
-        FlowRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Button(onClick = onRecord) { Text(stringResource(R.string.record)) }
-            Button(onClick = onAddMemo) { Text(stringResource(R.string.text_memo)) }
-            Button(onClick = onViewRecordings) { Text(stringResource(R.string.view_recordings)) }
-            Button(onClick = onSettings) { Text(stringResource(R.string.settings)) }
-        }
-
+    Column(modifier = modifier.fillMaxSize()) {
         LazyColumn(
             modifier = Modifier
                 .weight(1f)


### PR DESCRIPTION
## Summary
- Replace inline buttons with NavigationBar-based navigation for recording, text memo, recordings, and settings
- Remove redundant action buttons from notes list screen
- Include Material icons dependency for navigation icons

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c5196e1808832580b2e46e93824487