### PR TITLE
Refactor MemoProcessor to load templates from resources

### DIFF
--- a/app/src/main/resources/llm/base_url.txt
+++ b/app/src/main/resources/llm/base_url.txt
@@ -1,0 +1,1 @@
+https://openrouter.ai/api/v1/chat/completions

--- a/app/src/main/resources/llm/request.json
+++ b/app/src/main/resources/llm/request.json
@@ -1,0 +1,14 @@
+{
+  "model": "mistralai/mistral-nemo",
+  "messages": [
+    {"role":"system","content":"{system}"},
+    {"role":"user","content":"{user}"}
+  ],
+  "response_format": {
+    "type":"json_schema",
+    "json_schema": {
+      "name":"update",
+      "schema": {schema}
+    }
+  }
+}

--- a/app/src/main/resources/llm/schema/appointment.json
+++ b/app/src/main/resources/llm/schema/appointment.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "updated": { "type": "string" },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "text": { "type": "string" },
+          "datetime": { "type": "string" },
+          "location": { "type": "string" }
+        },
+        "required": ["text", "datetime"]
+      }
+    }
+  },
+  "required": ["updated", "items"]
+}

--- a/app/src/main/resources/llm/schema/base.json
+++ b/app/src/main/resources/llm/schema/base.json
@@ -1,0 +1,7 @@
+{
+  "type": "object",
+  "properties": {
+    "updated": { "type": "string" }
+  },
+  "required": ["updated"]
+}

--- a/app/src/main/resources/llm/schema/thought.json
+++ b/app/src/main/resources/llm/schema/thought.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "updated": { "type": "string" },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "text": { "type": "string" },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "required": ["text", "tags"]
+      }
+    }
+  },
+  "required": ["updated", "items"]
+}

--- a/app/src/main/resources/llm/schema/todo.json
+++ b/app/src/main/resources/llm/schema/todo.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "updated": { "type": "string" },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "text": { "type": "string" },
+          "status": { "type": "string" },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "required": ["text", "status", "tags"]
+      }
+    }
+  },
+  "required": ["updated", "items"]
+}


### PR DESCRIPTION
## Summary
- Load base URL, request template, and JSON schemas from resource files
- Replace hardcoded schema and path strings in `MemoProcessor`
- Parse JSON content without regex dependency

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c53c6fa8c883259f6e9e41c556d64e