### PR TITLE
Organize appointments by date and enable deletion

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -243,6 +243,12 @@ fun DianaApp(repository: NoteRepository) {
                     scope.launch {
                         repository.deleteTodoItem(item.text)
                     }
+                },
+                onAppointmentDelete = { appt ->
+                    appointments = appointments.filterNot { it == appt }
+                    scope.launch {
+                        repository.deleteAppointment(appt.text, appt.datetime, appt.location)
+                    }
                 }
             )
             Screen.Recordings -> RecordedMemosScreen(recordedMemos, player) { screen = Screen.List }

--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -15,6 +15,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.IOException
 import java.util.Locale
+import java.time.LocalDate
 import java.util.concurrent.TimeUnit
 import kotlin.collections.ArrayDeque
 import android.util.Log
@@ -78,6 +79,7 @@ class MemoProcessor(
             .replace("{aspect}", aspect)
             .replace("{prior}", prior)
             .replace("{memo}", memo)
+            .replace("{today}", LocalDate.now().toString())
         val json = requestTemplate
             .replace("{system}", system)
             .replace("{user}", user)
@@ -241,21 +243,21 @@ data class Prompts(
                     appointments = "lista degli appuntamenti",
                     thoughts = "pensieri e note",
                     systemTemplate = "Gestisci un documento {aspect}. Restituisci solo JSON.",
-                    userTemplate = "Stato attuale della {aspect}:\n{prior}\n\nNuovo memo:\n{memo}\n\nRestituisci la {aspect} aggiornata nel campo 'updated', nella stessa lingua del nuovo memo."
+                    userTemplate = "Stato attuale della {aspect}:\n{prior}\n\nData odierna: {today}\n\nNuovo memo:\n{memo}\n\nRestituisci la {aspect} aggiornata nel campo 'updated', nella stessa lingua del nuovo memo."
                 )
                 "fr" -> Prompts(
                     todo = "liste de tâches",
                     appointments = "liste des rendez-vous",
                     thoughts = "pensées et notes",
                     systemTemplate = "Vous maintenez un document de {aspect}. Retournez uniquement du JSON.",
-                    userTemplate = "État actuel de la {aspect}:\n{prior}\n\nNouveau mémo:\n{memo}\n\nRetournez la {aspect} mise à jour dans le champ 'updated', dans la même langue que le nouveau mémo."
+                    userTemplate = "État actuel de la {aspect}:\n{prior}\n\nDate du jour: {today}\n\nNouveau mémo:\n{memo}\n\nRetournez la {aspect} mise à jour dans le champ 'updated', dans la même langue que le nouveau mémo."
                 )
                 else -> Prompts(
                     todo = "to-do list",
                     appointments = "appointments list",
                     thoughts = "thoughts and notes",
                     systemTemplate = "You maintain a {aspect} document. Return only JSON.",
-                    userTemplate = "Current {aspect}:\n{prior}\n\nNew memo:\n{memo}\n\nReturn the updated {aspect} in the field 'updated', in the same language as the new memo."
+                    userTemplate = "Current {aspect}:\n{prior}\n\nToday's date: {today}\n\nNew memo:\n{memo}\n\nReturn the updated {aspect} in the field 'updated', in the same language as the new memo."
                 )
             }
         }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -28,4 +28,6 @@
     <string name="cancel">Annuler</string>
     <string name="delete_todo_title">Supprimer la tâche</string>
     <string name="delete_todo_message">Êtes-vous sûr de vouloir supprimer cette tâche ?</string>
+    <string name="delete_appointment_title">Supprimer le rendez-vous</string>
+    <string name="delete_appointment_message">Êtes-vous sûr de vouloir supprimer ce rendez-vous ?</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -28,4 +28,6 @@
     <string name="cancel">Annulla</string>
     <string name="delete_todo_title">Elimina attività</string>
     <string name="delete_todo_message">Sei sicuro di voler eliminare questa attività?</string>
+    <string name="delete_appointment_title">Elimina appuntamento</string>
+    <string name="delete_appointment_message">Sei sicuro di voler eliminare questo appuntamento?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,6 @@
     <string name="cancel">Cancel</string>
     <string name="delete_todo_title">Delete to-do</string>
     <string name="delete_todo_message">Are you sure you want to delete this to-do?</string>
+    <string name="delete_appointment_title">Delete appointment</string>
+    <string name="delete_appointment_message">Are you sure you want to delete this appointment?</string>
 </resources>

--- a/app/src/main/resources/llm/schema/appointment.json
+++ b/app/src/main/resources/llm/schema/appointment.json
@@ -8,7 +8,7 @@
         "type": "object",
         "properties": {
           "text": { "type": "string" },
-          "datetime": { "type": "string" },
+          "datetime": { "type": "string", "minLength": 1 },
           "location": { "type": "string" }
         },
         "required": ["text", "datetime"]

--- a/app/src/test/java/li/crescio/penates/diana/llm/PromptsTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/llm/PromptsTest.kt
@@ -12,7 +12,7 @@ class PromptsTest {
         assertEquals("lista degli appuntamenti", prompts.appointments)
         assertEquals("pensieri e note", prompts.thoughts)
         assertEquals("Gestisci un documento {aspect}. Restituisci solo JSON.", prompts.systemTemplate)
-        val expectedUserTemplate = "Stato attuale della {aspect}:\n{prior}\n\nNuovo memo:\n{memo}\n\nRestituisci la {aspect} aggiornata nel campo 'updated', nella stessa lingua del nuovo memo."
+        val expectedUserTemplate = "Stato attuale della {aspect}:\n{prior}\n\nData odierna: {today}\n\nNuovo memo:\n{memo}\n\nRestituisci la {aspect} aggiornata nel campo 'updated', nella stessa lingua del nuovo memo."
         assertEquals(expectedUserTemplate, prompts.userTemplate)
     }
 
@@ -23,7 +23,7 @@ class PromptsTest {
         assertEquals("liste des rendez-vous", prompts.appointments)
         assertEquals("pensées et notes", prompts.thoughts)
         assertEquals("Vous maintenez un document de {aspect}. Retournez uniquement du JSON.", prompts.systemTemplate)
-        val expectedUserTemplate = "État actuel de la {aspect}:\n{prior}\n\nNouveau mémo:\n{memo}\n\nRetournez la {aspect} mise à jour dans le champ 'updated', dans la même langue que le nouveau mémo."
+        val expectedUserTemplate = "État actuel de la {aspect}:\n{prior}\n\nDate du jour: {today}\n\nNouveau mémo:\n{memo}\n\nRetournez la {aspect} mise à jour dans le champ 'updated', dans la même langue que le nouveau mémo."
         assertEquals(expectedUserTemplate, prompts.userTemplate)
     }
 
@@ -34,7 +34,7 @@ class PromptsTest {
         assertEquals("appointments list", prompts.appointments)
         assertEquals("thoughts and notes", prompts.thoughts)
         assertEquals("You maintain a {aspect} document. Return only JSON.", prompts.systemTemplate)
-        val expectedUserTemplate = "Current {aspect}:\n{prior}\n\nNew memo:\n{memo}\n\nReturn the updated {aspect} in the field 'updated', in the same language as the new memo."
+        val expectedUserTemplate = "Current {aspect}:\n{prior}\n\nToday's date: {today}\n\nNew memo:\n{memo}\n\nReturn the updated {aspect} in the field 'updated', in the same language as the new memo."
         assertEquals(expectedUserTemplate, prompts.userTemplate)
     }
 }


### PR DESCRIPTION
## Summary
- Group appointments by date in the notes list and allow removing individual entries
- Include current date in LLM prompts and require non-empty appointment dates
- Add repository support and tests for deleting appointments

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.MemoProcessorTest" --console=plain --rerun-tasks`
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.persistence.NoteRepositoryTest" --console=plain --rerun-tasks`
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.PromptsTest" --console=plain --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68c56f098bf08325932c136acc96472e