### PR TITLE
Align settings screen style with main page

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -16,17 +17,35 @@ fun SettingsScreen(
     onClearThoughts: () -> Unit,
     onBack: () -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)
-    ) {
-        Button(onClick = onClearTodos) { Text(stringResource(R.string.clear_todo)) }
-        Spacer(modifier = Modifier.height(8.dp))
-        Button(onClick = onClearAppointments) { Text(stringResource(R.string.clear_appointments)) }
-        Spacer(modifier = Modifier.height(8.dp))
-        Button(onClick = onClearThoughts) { Text(stringResource(R.string.clear_thoughts)) }
-        Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = onBack) { Text(stringResource(R.string.back)) }
+    Column(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Button(onClick = onBack) { Text(stringResource(R.string.back)) }
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 16.dp)
+        ) {
+            Button(
+                onClick = onClearTodos,
+                modifier = Modifier.fillMaxWidth()
+            ) { Text(stringResource(R.string.clear_todo)) }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(
+                onClick = onClearAppointments,
+                modifier = Modifier.fillMaxWidth()
+            ) { Text(stringResource(R.string.clear_appointments)) }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(
+                onClick = onClearThoughts,
+                modifier = Modifier.fillMaxWidth()
+            ) { Text(stringResource(R.string.clear_thoughts)) }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Match settings screen layout with main UI by centering the back button and using full-width action buttons

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: Archive is not a ZIP archive)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ae1e718083259caf0cf81e31734e