### PR TITLE
Preserve existing todo items across memo processing

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -164,7 +164,7 @@ class MemoProcessor(
         val itemsArr = obj.optJSONArray("items")
         when (aspect) {
             prompts.todo -> {
-                todoItems = (0 until (itemsArr?.length() ?: 0)).mapNotNull { idx ->
+                val newItems = (0 until (itemsArr?.length() ?: 0)).mapNotNull { idx ->
                     val itemObj = itemsArr?.optJSONObject(idx) ?: return@mapNotNull null
                     val text = itemObj.optString("text")
                     val status = itemObj.optString("status")
@@ -172,6 +172,11 @@ class MemoProcessor(
                     val tags = (0 until (tagsArr?.length() ?: 0)).map { tagsArr.optString(it) }
                     if (text.isBlank()) null else TodoItem(text, status, tags)
                 }
+                val merged = todoItems.associateBy { it.text }.toMutableMap()
+                for (item in newItems) {
+                    merged[item.text] = item
+                }
+                todoItems = merged.values.toList()
             }
             prompts.appointments -> {
                 appointmentItems = (0 until (itemsArr?.length() ?: 0)).mapNotNull { idx ->

--- a/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
@@ -4,6 +4,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import li.crescio.penates.diana.notes.Memo
+import li.crescio.penates.diana.llm.TodoItem
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -49,6 +50,48 @@ class MemoProcessorTest {
         assertEquals("thoughts updated", summary.thoughts)
         assertTrue(summary.appointmentItems.isEmpty())
         verify(exactly = 3) { logger.log(any(), any()) }
+
+        server.shutdown()
+    }
+
+    @Test
+    fun process_appendsTodoItems() = runBlocking {
+        System.setProperty("net.bytebuddy.experimental", "true")
+
+        val server = MockWebServer()
+        fun completion(vararg items: JSONObject): String {
+            val itemsArr = JSONArray()
+            items.forEach { itemsArr.put(it) }
+            val content = JSONObject().put("updated", "u").put("items", itemsArr)
+            val message = JSONObject().put("content", content.toString())
+            val choice = JSONObject().put("message", message)
+            val choices = JSONArray().put(choice)
+            return JSONObject().put("choices", choices).toString()
+        }
+        val item1 = JSONObject().put("text", "first").put("status", "").put("tags", JSONArray())
+        val item2 = JSONObject().put("text", "second").put("status", "").put("tags", JSONArray())
+        server.enqueue(MockResponse().setBody(completion(item1)).setResponseCode(200))
+        server.enqueue(MockResponse().setBody(completion(item2)).setResponseCode(200))
+        server.start()
+
+        val processor = MemoProcessor(
+            apiKey = "key",
+            logger = mockk(relaxed = true),
+            locale = Locale.ENGLISH,
+            baseUrl = server.url("/").toString(),
+            client = OkHttpClient(),
+        )
+
+        processor.process(Memo("first"), processAppointments = false, processThoughts = false)
+        val summary = processor.process(Memo("second"), processAppointments = false, processThoughts = false)
+
+        assertEquals(
+            listOf(
+                TodoItem("first", "", emptyList()),
+                TodoItem("second", "", emptyList())
+            ),
+            summary.todoItems
+        )
 
         server.shutdown()
     }


### PR DESCRIPTION
## Summary
- Merge new todo items into existing list instead of overwriting it
- Add regression test to ensure todo items accumulate across memo processing

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.MemoProcessorTest.process_appendsTodoItems"`


------
https://chatgpt.com/codex/tasks/task_e_68c5c663dfc0832585f6b8dde8e4b006