### PR TITLE
Load LLM prompts from resource files

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -252,30 +252,22 @@ data class Prompts(
     val userTemplate: String
 ) {
     companion object {
+        private fun load(locale: String, name: String): String =
+            loadResource("llm/prompts/$locale/$name.txt").trim()
+
         fun forLocale(locale: Locale): Prompts {
-            return when (locale.language) {
-                "it" -> Prompts(
-                    todo = "lista di cose da fare",
-                    appointments = "lista degli appuntamenti",
-                    thoughts = "pensieri e note",
-                    systemTemplate = "Gestisci un documento {aspect}. Restituisci solo JSON.",
-                    userTemplate = "Stato attuale della {aspect}:\n{prior}\n\nData odierna: {today}\n\nNuovo memo:\n{memo}\n\nRestituisci la {aspect} aggiornata nel campo 'updated', nella stessa lingua del nuovo memo."
-                )
-                "fr" -> Prompts(
-                    todo = "liste de tâches",
-                    appointments = "liste des rendez-vous",
-                    thoughts = "pensées et notes",
-                    systemTemplate = "Vous maintenez un document de {aspect}. Retournez uniquement du JSON.",
-                    userTemplate = "État actuel de la {aspect}:\n{prior}\n\nDate du jour: {today}\n\nNouveau mémo:\n{memo}\n\nRetournez la {aspect} mise à jour dans le champ 'updated', dans la même langue que le nouveau mémo."
-                )
-                else -> Prompts(
-                    todo = "to-do list",
-                    appointments = "appointments list",
-                    thoughts = "thoughts and notes",
-                    systemTemplate = "You maintain a {aspect} document. Return only JSON.",
-                    userTemplate = "Current {aspect}:\n{prior}\n\nToday's date: {today}\n\nNew memo:\n{memo}\n\nReturn the updated {aspect} in the field 'updated', in the same language as the new memo."
-                )
+            val lang = when (locale.language) {
+                "it" -> "it"
+                "fr" -> "fr"
+                else -> "en"
             }
+            return Prompts(
+                todo = load(lang, "todo"),
+                appointments = load(lang, "appointments"),
+                thoughts = load(lang, "thoughts"),
+                systemTemplate = load(lang, "system"),
+                userTemplate = load(lang, "user"),
+            )
         }
     }
 }

--- a/app/src/main/resources/llm/prompts/en/appointments.txt
+++ b/app/src/main/resources/llm/prompts/en/appointments.txt
@@ -1,0 +1,1 @@
+appointments list

--- a/app/src/main/resources/llm/prompts/en/system.txt
+++ b/app/src/main/resources/llm/prompts/en/system.txt
@@ -1,0 +1,1 @@
+You maintain a {aspect} document. Return only JSON.

--- a/app/src/main/resources/llm/prompts/en/thoughts.txt
+++ b/app/src/main/resources/llm/prompts/en/thoughts.txt
@@ -1,0 +1,1 @@
+thoughts and notes

--- a/app/src/main/resources/llm/prompts/en/todo.txt
+++ b/app/src/main/resources/llm/prompts/en/todo.txt
@@ -1,0 +1,1 @@
+to-do list

--- a/app/src/main/resources/llm/prompts/en/user.txt
+++ b/app/src/main/resources/llm/prompts/en/user.txt
@@ -1,0 +1,9 @@
+Current {aspect}:
+{prior}
+
+Today's date: {today}
+
+New memo:
+{memo}
+
+Return the updated {aspect} in the field 'updated', in the same language as the new memo.

--- a/app/src/main/resources/llm/prompts/fr/appointments.txt
+++ b/app/src/main/resources/llm/prompts/fr/appointments.txt
@@ -1,0 +1,1 @@
+liste des rendez-vous

--- a/app/src/main/resources/llm/prompts/fr/system.txt
+++ b/app/src/main/resources/llm/prompts/fr/system.txt
@@ -1,0 +1,1 @@
+Vous maintenez un document de {aspect}. Retournez uniquement du JSON.

--- a/app/src/main/resources/llm/prompts/fr/thoughts.txt
+++ b/app/src/main/resources/llm/prompts/fr/thoughts.txt
@@ -1,0 +1,1 @@
+pensées et notes

--- a/app/src/main/resources/llm/prompts/fr/todo.txt
+++ b/app/src/main/resources/llm/prompts/fr/todo.txt
@@ -1,0 +1,1 @@
+liste de tâches

--- a/app/src/main/resources/llm/prompts/fr/user.txt
+++ b/app/src/main/resources/llm/prompts/fr/user.txt
@@ -1,0 +1,9 @@
+État actuel de la {aspect}:
+{prior}
+
+Date du jour: {today}
+
+Nouveau mémo:
+{memo}
+
+Retournez la {aspect} mise à jour dans le champ 'updated', dans la même langue que le nouveau mémo.

--- a/app/src/main/resources/llm/prompts/it/appointments.txt
+++ b/app/src/main/resources/llm/prompts/it/appointments.txt
@@ -1,0 +1,1 @@
+lista degli appuntamenti

--- a/app/src/main/resources/llm/prompts/it/system.txt
+++ b/app/src/main/resources/llm/prompts/it/system.txt
@@ -1,0 +1,1 @@
+Gestisci un documento {aspect}. Restituisci solo JSON.

--- a/app/src/main/resources/llm/prompts/it/thoughts.txt
+++ b/app/src/main/resources/llm/prompts/it/thoughts.txt
@@ -1,0 +1,1 @@
+pensieri e note

--- a/app/src/main/resources/llm/prompts/it/todo.txt
+++ b/app/src/main/resources/llm/prompts/it/todo.txt
@@ -1,0 +1,1 @@
+lista di cose da fare

--- a/app/src/main/resources/llm/prompts/it/user.txt
+++ b/app/src/main/resources/llm/prompts/it/user.txt
@@ -1,0 +1,9 @@
+Stato attuale della {aspect}:
+{prior}
+
+Data odierna: {today}
+
+Nuovo memo:
+{memo}
+
+Restituisci la {aspect} aggiornata nel campo 'updated', nella stessa lingua del nuovo memo.

--- a/app/src/test/java/li/crescio/penates/diana/llm/PromptsTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/llm/PromptsTest.kt
@@ -3,39 +3,42 @@ package li.crescio.penates.diana.llm
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.util.Locale
+import java.io.IOException
 
 class PromptsTest {
+    private fun load(path: String): String {
+        val stream = this::class.java.classLoader?.getResourceAsStream(path)
+            ?: throw IOException("Resource $path not found")
+        return stream.bufferedReader().use { it.readText().trim() }
+    }
     @Test
     fun forLocale_returnsItalianPrompts() {
         val prompts = Prompts.forLocale(Locale("it"))
-        assertEquals("lista di cose da fare", prompts.todo)
-        assertEquals("lista degli appuntamenti", prompts.appointments)
-        assertEquals("pensieri e note", prompts.thoughts)
-        assertEquals("Gestisci un documento {aspect}. Restituisci solo JSON.", prompts.systemTemplate)
-        val expectedUserTemplate = "Stato attuale della {aspect}:\n{prior}\n\nData odierna: {today}\n\nNuovo memo:\n{memo}\n\nRestituisci la {aspect} aggiornata nel campo 'updated', nella stessa lingua del nuovo memo."
-        assertEquals(expectedUserTemplate, prompts.userTemplate)
+        assertEquals(load("llm/prompts/it/todo.txt"), prompts.todo)
+        assertEquals(load("llm/prompts/it/appointments.txt"), prompts.appointments)
+        assertEquals(load("llm/prompts/it/thoughts.txt"), prompts.thoughts)
+        assertEquals(load("llm/prompts/it/system.txt"), prompts.systemTemplate)
+        assertEquals(load("llm/prompts/it/user.txt"), prompts.userTemplate)
     }
 
     @Test
     fun forLocale_returnsFrenchPrompts() {
         val prompts = Prompts.forLocale(Locale("fr"))
-        assertEquals("liste de tâches", prompts.todo)
-        assertEquals("liste des rendez-vous", prompts.appointments)
-        assertEquals("pensées et notes", prompts.thoughts)
-        assertEquals("Vous maintenez un document de {aspect}. Retournez uniquement du JSON.", prompts.systemTemplate)
-        val expectedUserTemplate = "État actuel de la {aspect}:\n{prior}\n\nDate du jour: {today}\n\nNouveau mémo:\n{memo}\n\nRetournez la {aspect} mise à jour dans le champ 'updated', dans la même langue que le nouveau mémo."
-        assertEquals(expectedUserTemplate, prompts.userTemplate)
+        assertEquals(load("llm/prompts/fr/todo.txt"), prompts.todo)
+        assertEquals(load("llm/prompts/fr/appointments.txt"), prompts.appointments)
+        assertEquals(load("llm/prompts/fr/thoughts.txt"), prompts.thoughts)
+        assertEquals(load("llm/prompts/fr/system.txt"), prompts.systemTemplate)
+        assertEquals(load("llm/prompts/fr/user.txt"), prompts.userTemplate)
     }
 
     @Test
     fun forLocale_returnsDefaultPrompts() {
         val prompts = Prompts.forLocale(Locale("en"))
-        assertEquals("to-do list", prompts.todo)
-        assertEquals("appointments list", prompts.appointments)
-        assertEquals("thoughts and notes", prompts.thoughts)
-        assertEquals("You maintain a {aspect} document. Return only JSON.", prompts.systemTemplate)
-        val expectedUserTemplate = "Current {aspect}:\n{prior}\n\nToday's date: {today}\n\nNew memo:\n{memo}\n\nReturn the updated {aspect} in the field 'updated', in the same language as the new memo."
-        assertEquals(expectedUserTemplate, prompts.userTemplate)
+        assertEquals(load("llm/prompts/en/todo.txt"), prompts.todo)
+        assertEquals(load("llm/prompts/en/appointments.txt"), prompts.appointments)
+        assertEquals(load("llm/prompts/en/thoughts.txt"), prompts.thoughts)
+        assertEquals(load("llm/prompts/en/system.txt"), prompts.systemTemplate)
+        assertEquals(load("llm/prompts/en/user.txt"), prompts.userTemplate)
     }
 }
 


### PR DESCRIPTION
## Summary
- Move LLM prompt text into resource files for English, French, and Italian
- Load localized prompts from those files instead of hardcoded strings
- Update unit tests to verify prompts match their resource templates

## Testing
- `./gradlew --console=plain :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.PromptsTest" --tests "li.crescio.penates.diana.llm.MemoProcessorTest"`

------
https://chatgpt.com/codex/tasks/task_e_68c5cf8df8908325ab4ba8896516e93a