### PR TITLE
Persist memos and allow reprocessing from archive

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/MemoArchiveScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/MemoArchiveScreen.kt
@@ -8,17 +8,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import li.crescio.penates.diana.R
 import li.crescio.penates.diana.notes.Memo
 import li.crescio.penates.diana.player.Player
-import androidx.compose.ui.res.stringResource
-import li.crescio.penates.diana.R
 
 @Composable
-fun RecordedMemosScreen(
+fun MemoArchiveScreen(
     memos: List<Memo>,
     player: Player,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onReprocess: (Memo) -> Unit
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         Box(
@@ -34,15 +35,27 @@ fun RecordedMemosScreen(
             items(memos) { memo ->
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
                 ) {
-                    Button(onClick = { memo.audioPath?.let { player.play(it) } }) { Text(stringResource(R.string.play)) }
+                    if (memo.audioPath != null) {
+                        Button(onClick = { player.play(memo.audioPath) }) {
+                            Text(stringResource(R.string.play))
+                        }
+                    }
                     Text(
                         memo.text,
-                        modifier = Modifier.padding(start = 16.dp)
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(start = 16.dp)
                     )
+                    Button(onClick = { onReprocess(memo) }) {
+                        Text(stringResource(R.string.reprocess))
+                    }
                 }
             }
         }
     }
 }
+

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2,12 +2,13 @@
     <string name="app_name">Diana</string>
     <string name="record">Enregistrer</string>
     <string name="text_memo">Mémo texte</string>
-    <string name="view_recordings">Voir les enregistrements</string>
+    <string name="memo_archive">Archive des mémos</string>
     <string name="todo_list">Liste de tâches</string>
     <string name="appointments">Rendez-vous</string>
     <string name="thoughts_notes">Pensées et notes</string>
     <string name="back">Retour</string>
     <string name="play">Lire</string>
+    <string name="reprocess">Re-traiter</string>
     <string name="settings">Paramètres</string>
     <string name="finish_recording">Terminer l\'enregistrement</string>
     <string name="save">Sauvegarder</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -2,12 +2,13 @@
     <string name="app_name">Diana</string>
     <string name="record">Registra</string>
     <string name="text_memo">Nota di testo</string>
-    <string name="view_recordings">Vedi registrazioni</string>
+    <string name="memo_archive">Archivio memo</string>
     <string name="todo_list">Lista di cose da fare</string>
     <string name="appointments">Appuntamenti</string>
     <string name="thoughts_notes">Pensieri e note</string>
     <string name="back">Indietro</string>
     <string name="play">Riproduci</string>
+    <string name="reprocess">Rielabora</string>
     <string name="settings">Impostazioni</string>
     <string name="finish_recording">Termina registrazione</string>
     <string name="save">Salva</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,13 +2,14 @@
     <string name="app_name">Diana</string>
     <string name="record">Record</string>
     <string name="text_memo">Text Memo</string>
-    <string name="view_recordings">View Recordings</string>
+    <string name="memo_archive">Memo Archive</string>
     <string name="todo_list">To-Do List</string>
     <string name="appointments">Appointments</string>
     <string name="thoughts_notes">Thoughts &amp; Notes</string>
     <string name="filter_tag">Filter by tag</string>
     <string name="back">Back</string>
     <string name="play">Play</string>
+    <string name="reprocess">Reprocess</string>
     <string name="settings">Settings</string>
     <string name="finish_recording">Finish Recording</string>
     <string name="save">Save</string>

--- a/app/src/test/java/li/crescio/penates/diana/persistence/MemoRepositoryTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/persistence/MemoRepositoryTest.kt
@@ -1,0 +1,34 @@
+package li.crescio.penates.diana.persistence
+
+import kotlinx.coroutines.runBlocking
+import li.crescio.penates.diana.notes.Memo
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+class MemoRepositoryTest {
+    private lateinit var file: File
+    private lateinit var repository: MemoRepository
+
+    @Before
+    fun setup() {
+        file = File.createTempFile("memos", ".txt")
+        repository = MemoRepository(file)
+    }
+
+    @After
+    fun teardown() {
+        file.delete()
+    }
+
+    @Test
+    fun addAndLoadMemos() = runBlocking {
+        repository.addMemo(Memo("one"))
+        repository.addMemo(Memo("two", "audio"))
+        val memos = repository.loadMemos()
+        assertEquals(listOf(Memo("one"), Memo("two", "audio")), memos)
+    }
+}
+


### PR DESCRIPTION
## Summary
- save text memos and transcriptions with new MemoRepository
- add memo archive screen with play and reprocess actions
- expose archive from navigation and store new memos for replay

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.persistence.MemoRepositoryTest"`


------
https://chatgpt.com/codex/tasks/task_e_68c65a45c4148325ac8a54f096b4fe10