### PR TITLE
Seed memo processor with existing notes

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -57,6 +57,16 @@ class MemoProcessor(
     private val appointmentSchema = loadResource("llm/schema/appointment.json")
     private val thoughtSchema = loadResource("llm/schema/thought.json")
 
+    /** Seed the processor with an existing summary. */
+    fun initialize(summary: MemoSummary) {
+        todo = summary.todo
+        todoItems = summary.todoItems
+        appointments = summary.appointments
+        appointmentItems = summary.appointmentItems
+        thoughts = summary.thoughts
+        thoughtItems = summary.thoughtItems
+    }
+
     /**
      * Update the running summaries based on [memo] and return the latest values.
      */


### PR DESCRIPTION
## Summary
- add initialize() to MemoProcessor to seed internal buffers
- initialize memo processor after notes load in MainActivity
- test that initialized todos persist and append correctly

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.MemoProcessorTest"`


------
https://chatgpt.com/codex/tasks/task_e_68c67e5f88a48325ac6c26f384716734