### PR TITLE
Build LLM request from template using Jackson

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.17.1'
     implementation platform('com.google.firebase:firebase-bom:32.7.3')
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
     implementation 'com.google.firebase:firebase-analytics-ktx'


### PR DESCRIPTION
## Summary
- Restore request.json template to avoid hardcoded request structure
- Escape system and user messages with Jackson's `JsonStringEncoder.quoteAsString`
- Add Jackson core dependency for JSON string quoting

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.MemoProcessorTest"`
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.PromptsTest"`


------
https://chatgpt.com/codex/tasks/task_e_68c6a81652748325b9c3eef152164cfc