### PR TITLE
Add strikethrough styling for completed tasks

### DIFF
--- a/app/src/androidTest/java/li/crescio/penates/diana/ui/NotesListScreenTest.kt
+++ b/app/src/androidTest/java/li/crescio/penates/diana/ui/NotesListScreenTest.kt
@@ -1,0 +1,48 @@
+package li.crescio.penates.diana.ui
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import li.crescio.penates.diana.llm.TodoItem
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class NotesListScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun doneTodo_showsStrikethrough() {
+        val item = TodoItem(
+            text = "Finished task",
+            status = "done",
+            tags = listOf("tag"),
+        )
+        composeTestRule.setContent {
+            NotesListScreen(
+                todoItems = listOf(item),
+                appointments = emptyList(),
+                notes = emptyList(),
+                logs = emptyList(),
+                showTodos = true,
+                showAppointments = false,
+                showThoughts = false,
+                onTodoCheckedChange = { _, _ -> },
+                onTodoDelete = {},
+                onAppointmentDelete = {}
+            )
+        }
+
+        composeTestRule.onNodeWithText("Finished task").assertIsDisplayed()
+        val annotated = composeTestRule.onNodeWithText("Finished task")
+            .fetchSemanticsNode()
+            .config[SemanticsProperties.Text].first()
+        assertTrue(annotated.spanStyles.any { it.item.textDecoration == TextDecoration.LineThrough })
+    }
+}

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import li.crescio.penates.diana.R
 import li.crescio.penates.diana.llm.Appointment
@@ -81,18 +82,40 @@ fun NotesListScreen(
                                             .padding(start = 8.dp)
                                             .weight(1f)
                                     ) {
-                                        Text(item.text)
+                                        val textColor = if (item.status == "done") {
+                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurface
+                                        }
+                                        val decoration = if (item.status == "done") {
+                                            TextDecoration.LineThrough
+                                        } else {
+                                            TextDecoration.None
+                                        }
+                                        Text(
+                                            item.text,
+                                            color = textColor,
+                                            textDecoration = decoration
+                                        )
                                         parseDate(item.dueDate.ifBlank { item.eventDate })?.let { date ->
                                             Text(
                                                 date.format(dateFormatter),
-                                                style = MaterialTheme.typography.bodySmall
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = textColor,
+                                                textDecoration = decoration
                                             )
                                         }
                                         Row {
                                             item.tags.forEach { tag ->
                                                 AssistChip(
                                                     onClick = {},
-                                                    label = { Text(tag) },
+                                                    label = {
+                                                        Text(
+                                                            tag,
+                                                            color = textColor,
+                                                            textDecoration = decoration
+                                                        )
+                                                    },
                                                     modifier = Modifier.padding(end = 4.dp)
                                                 )
                                             }


### PR DESCRIPTION
## Summary
- Muted styling and strikethrough for completed to-dos, including tags and dates
- UI test confirms done tasks render with strikethrough

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:connectedAndroidTest` *(fails: No connected devices)*


------
https://chatgpt.com/codex/tasks/task_e_68c71de3ac008325970e88bf53854911