### PR TITLE
Highlight urgent todos

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -82,11 +82,15 @@ fun NotesListScreen(
                                             .padding(start = 8.dp)
                                             .weight(1f)
                                     ) {
-                                        val textColor = if (item.status == "done") {
+                                        val baseColor = if (item.status == "done") {
                                             MaterialTheme.colorScheme.onSurfaceVariant
                                         } else {
                                             MaterialTheme.colorScheme.onSurface
                                         }
+                                        val textColor = calculateUrgencyColor(
+                                            item.dueDate.ifBlank { item.eventDate },
+                                            baseColor
+                                        )
                                         val decoration = if (item.status == "done") {
                                             TextDecoration.LineThrough
                                         } else {

--- a/app/src/main/java/li/crescio/penates/diana/ui/UrgencyColor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/UrgencyColor.kt
@@ -1,0 +1,21 @@
+package li.crescio.penates.diana.ui
+
+import androidx.compose.ui.graphics.Color
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+
+private const val DUE_SOON_THRESHOLD_DAYS = 3L
+
+fun calculateUrgencyColor(dueDate: String?, defaultColor: Color): Color {
+    if (dueDate.isNullOrBlank()) return defaultColor
+    val date = runCatching { OffsetDateTime.parse(dueDate).toLocalDate() }
+        .recoverCatching { LocalDate.parse(dueDate) }
+        .getOrNull() ?: return defaultColor
+    val daysUntil = ChronoUnit.DAYS.between(LocalDate.now(), date)
+    return when {
+        daysUntil < 0 -> Color.Red
+        daysUntil <= DUE_SOON_THRESHOLD_DAYS -> Color(0xFFFFA500)
+        else -> defaultColor
+    }
+}

--- a/app/src/test/java/li/crescio/penates/diana/ui/CalculateUrgencyColorTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/ui/CalculateUrgencyColorTest.kt
@@ -1,0 +1,43 @@
+package li.crescio.penates.diana.ui
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Test
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+
+class CalculateUrgencyColorTest {
+    private val defaultColor = Color.Gray
+
+    @Test
+    fun returnsDefaultColorForBlankDate() {
+        val result = calculateUrgencyColor("", defaultColor)
+        assertEquals(defaultColor, result)
+    }
+
+    @Test
+    fun returnsDefaultColorForInvalidDate() {
+        val result = calculateUrgencyColor("not-a-date", defaultColor)
+        assertEquals(defaultColor, result)
+    }
+
+    @Test
+    fun returnsRedForOverdueDate() {
+        val pastDate = LocalDate.now().minusDays(1).toString()
+        val result = calculateUrgencyColor(pastDate, defaultColor)
+        assertEquals(Color.Red, result)
+    }
+
+    @Test
+    fun returnsOrangeForDueSoonDate() {
+        val soonDate = LocalDate.now().plusDays(2).toString()
+        val result = calculateUrgencyColor(soonDate, defaultColor)
+        assertEquals(Color(0xFFFFA500), result)
+    }
+
+    @Test
+    fun returnsDefaultColorForLaterDate() {
+        val laterDate = LocalDate.now().plusDays(10).toString()
+        val result = calculateUrgencyColor(laterDate, defaultColor)
+        assertEquals(defaultColor, result)
+    }
+}


### PR DESCRIPTION
## Summary
- add `calculateUrgencyColor` helper to flag overdue or soon-due items
- show urgency colors in the notes list to highlight upcoming todos
- cover edge cases with new unit tests

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.ui.CalculateUrgencyColorTest"`


------
https://chatgpt.com/codex/tasks/task_e_68c725bfacf08325a90653f9021b92ef