### PR TITLE
Move NotesListScreen test to unit tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,12 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -63,9 +69,10 @@ dependencies {
     testImplementation 'io.mockk:mockk:1.12.3'
     testImplementation 'org.json:json:20210307'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
+    testImplementation 'androidx.test.ext:junit:1.1.5'
+    testImplementation 'androidx.test:core:1.5.0'
+    testImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
+    testImplementation 'org.robolectric:robolectric:4.11.1'
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_ui_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_ui_version"
 }

--- a/app/src/test/java/li/crescio/penates/diana/ui/NotesListScreenTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/ui/NotesListScreenTest.kt
@@ -5,14 +5,16 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import li.crescio.penates.diana.llm.TodoItem
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.junit.Assert.assertTrue
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
 class NotesListScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()


### PR DESCRIPTION
## Summary
- move NotesListScreenTest from `androidTest` to `test`
- enable Robolectric-based Compose testing
- configure unit test dependencies for Compose UI

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.ui.NotesListScreenTest"` *(fails: java.net.SocketException at MavenArtifactFetcher)*

------
https://chatgpt.com/codex/tasks/task_e_68c806a75adc8325b201964b21783cc3