### PR TITLE
feat: add todo item ids and update schema

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -158,7 +158,7 @@ fun DianaApp(repository: NoteRepository, memoRepository: MemoRepository) {
         val eventNotes = notes.filterIsInstance<StructuredNote.Event>()
         val memoNotes = notes.filterIsInstance<StructuredNote.Memo>()
         val freeNotes = notes.filterIsInstance<StructuredNote.Free>()
-        todoItems = todoNotes.map { TodoItem(it.text, it.status, it.tags, it.dueDate, it.eventDate) }
+        todoItems = todoNotes.map { TodoItem(it.text, it.status, it.tags, it.dueDate, it.eventDate, it.id) }
         appointments = eventNotes.map { Appointment(it.text, it.datetime, it.location) }
         thoughtNotes = memoNotes + freeNotes
         syncProcessor()
@@ -275,11 +275,11 @@ fun DianaApp(repository: NoteRepository, memoRepository: MemoRepository) {
                 onTodoCheckedChange = { item, checked ->
                       val newStatus = if (checked) "done" else "not_started"
                     todoItems = todoItems.map {
-                        if (it.text == item.text) it.copy(status = newStatus) else it
+                        if (it.id == item.id) it.copy(status = newStatus) else it
                     }
                     scope.launch {
                           val todoNotes = todoItems.map {
-                              StructuredNote.ToDo(it.text, it.status, it.tags, it.dueDate, it.eventDate)
+                              StructuredNote.ToDo(it.text, it.status, it.tags, it.dueDate, it.eventDate, id = it.id)
                           }
                         val apptNotes = if (processAppointments) {
                             appointments.map {
@@ -292,9 +292,9 @@ fun DianaApp(repository: NoteRepository, memoRepository: MemoRepository) {
                     }
                 },
                 onTodoDelete = { item ->
-                    todoItems = todoItems.filterNot { it.text == item.text }
+                    todoItems = todoItems.filterNot { it.id == item.id }
                     scope.launch {
-                        repository.deleteTodoItem(item.text)
+                        repository.deleteTodoItem(item.id)
                         syncProcessor()
                     }
                 },

--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -102,6 +102,7 @@ class MemoProcessor(
             itemObj.put("tags", tagsArr)
             if (item.dueDate.isNotBlank()) itemObj.put("due_date", item.dueDate)
             if (item.eventDate.isNotBlank()) itemObj.put("event_date", item.eventDate)
+            if (item.id.isNotBlank()) itemObj.put("id", item.id)
             itemsArr.put(itemObj)
         }
         obj.put("items", itemsArr)
@@ -250,12 +251,13 @@ class MemoProcessor(
                     val tags = (0 until (tagsArr?.length() ?: 0)).map { tagsArr.optString(it) }
                     val dueDate = itemObj.optString("due_date", "")
                     val eventDate = itemObj.optString("event_date", "")
-                    if (text.isBlank()) null else op to TodoItem(text, status, tags, dueDate, eventDate)
+                    val id = itemObj.optString("id", "")
+                    if (text.isBlank()) null else op to TodoItem(text, status, tags, dueDate, eventDate, id)
                 }
-                val merged = todoItems.associateBy { it.text }.toMutableMap()
+                val merged = todoItems.associateBy { it.id.ifBlank { it.text } }.toMutableMap()
                 for ((op, item) in updates) {
                     when (op) {
-                        "add", "update" -> merged[item.text] = item
+                        "add", "update" -> merged[item.id.ifBlank { item.text }] = item
                     }
                 }
                 todoItems = merged.values.toList()
@@ -295,6 +297,7 @@ data class TodoItem(
     val tags: List<String>,
     val dueDate: String = "",
     val eventDate: String = "",
+    val id: String = "",
 )
 
 data class Appointment(val text: String, val datetime: String, val location: String)

--- a/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
+++ b/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
@@ -18,7 +18,8 @@ sealed class StructuredNote(open val createdAt: Long) {
         val tags: List<String> = emptyList(),
         val dueDate: String = "",
         val eventDate: String = "",
-        override val createdAt: Long = System.currentTimeMillis()
+        override val createdAt: Long = System.currentTimeMillis(),
+        val id: String = ""
     ) : StructuredNote(createdAt)
 
     data class Memo(

--- a/app/src/main/resources/llm/prompts/en/user.txt
+++ b/app/src/main/resources/llm/prompts/en/user.txt
@@ -12,6 +12,7 @@ Rules:
    - For each item choose "op":
        • "update" if new memo semantically matches an existing item in prior (see #3).
        • "add" if it introduces a new actionable task.
+   - When "op" = "update", include the item's "id" from prior. When "op" = "add", do NOT include "id".
    - Always return at least one item in "items".
    - Set "date" EXACTLY to {today}.
 
@@ -29,7 +30,6 @@ Rules:
    - Default: "not_started".
    - Use "in_progress" only if new memo clearly states the task is already underway (e.g., “I’m doing it”, “sto facendo”, “ya empecé”).
    - Use "done" only if new memo explicitly says it is completed.
-   - Use "not_required" if the task is no longer necessary.
    - Use "cancelled" if the task will not be done.
    - If updating an existing item that was "done", keep "done" unless new memo clearly reopens the task.
 

--- a/app/src/main/resources/llm/prompts/fr/user.txt
+++ b/app/src/main/resources/llm/prompts/fr/user.txt
@@ -13,8 +13,9 @@ Règles :
    - Pour chaque élément, choisissez "op" :  
        • "update" si le nouveau mémo correspond sémantiquement à un élément existant dans le prior (voir #3).  
        • "add" s’il introduit une nouvelle tâche actionnable.  
-   - Retournez toujours au moins un élément dans "items".  
-   - Fixez "date" EXACTEMENT à {today}.  
+   - Lorsque "op" = "update", incluez l'« id » de l’élément du prior. Lorsque "op" = "add", n’incluez PAS d’« id ».
+   - Retournez toujours au moins un élément dans "items".
+   - Fixez "date" EXACTEMENT à {today}.
 
 3) Déduplication / correspondance (déterministe)  
    - Normalisez pour comparer : mettre en minuscules, supprimer les accents, réduire les espaces, corriger les fautes fréquentes (ex. « analisis »→« analyse », « por que »→« pourquoi »).  
@@ -28,11 +29,10 @@ Règles :
 
 5) Statut (déterministe)  
    - Par défaut : "not_started".  
-   - Utilisez "in_progress" seulement si le mémo indique clairement que la tâche est en cours (ex. « je le fais », « je suis en train »).  
-   - Utilisez "done" seulement si le mémo indique explicitement que la tâche est terminée.  
-   - Utilisez "not_required" si la tâche n’est plus nécessaire.  
-   - Utilisez "cancelled" si la tâche ne sera pas faite.  
-   - Si vous mettez à jour un élément déjà "done", gardez "done" sauf si le mémo rouvre clairement la tâche.  
+   - Utilisez "in_progress" seulement si le mémo indique clairement que la tâche est en cours (ex. « je le fais », « je suis en train »).
+   - Utilisez "done" seulement si le mémo indique explicitement que la tâche est terminée.
+   - Utilisez "cancelled" si la tâche ne sera pas faite.
+   - Si vous mettez à jour un élément déjà "done", gardez "done" sauf si le mémo rouvre clairement la tâche.
 
 6) Tags  
    - Fournissez 1–3 tags courts, tous en minuscules, dans la langue du mémo (ex. français : « santé », « échéance », « suivi »).  

--- a/app/src/main/resources/llm/prompts/it/user.txt
+++ b/app/src/main/resources/llm/prompts/it/user.txt
@@ -8,12 +8,13 @@ Regole:
    - Usa la normale scrittura con iniziale maiuscola di frase (senza maiuscole casuali).  
 
 2) Cosa restituire  
-   - Restituisci SOLO il set minimo di elementi aggiunti o aggiornati a seguito del nuovo memo (NON l’intera lista).  
-   - Per ogni elemento scegli "op":  
-       • "update" se il nuovo memo corrisponde semanticamente a un elemento già presente nel prior (vedi #3).  
-       • "add" se introduce una nuova attività eseguibile.  
-   - Restituisci sempre almeno un elemento in "items".  
-   - Imposta "date" ESATTAMENTE a {today}.  
+   - Restituisci SOLO il set minimo di elementi aggiunti o aggiornati a seguito del nuovo memo (NON l’intera lista).
+   - Per ogni elemento scegli "op":
+       • "update" se il nuovo memo corrisponde semanticamente a un elemento già presente nel prior (vedi #3).
+       • "add" se introduce una nuova attività eseguibile.
+   - Quando "op" = "update", includi l'"id" dell'elemento dal prior. Quando "op" = "add", NON includere "id".
+   - Restituisci sempre almeno un elemento in "items".
+   - Imposta "date" ESATTAMENTE a {today}.
 
 3) Deduplicazione / corrispondenza (deterministica)  
    - Normalizza per confrontare: tutto in minuscolo, rimuovi accenti, riduci spazi, correggi errori comuni (es. « analysis »→« analisi », « perche »→« perché »).  
@@ -26,12 +27,11 @@ Regole:
    - Usa "due_date" per le scadenze e "event_date" per eventi programmati (AAAA-MM-GG). Se non applicabile, ometti questi campi.  
 
 5) Stato (deterministico)  
-   - Default: "not_started".  
-   - Usa "in_progress" solo se il nuovo memo indica chiaramente che l’attività è già in corso (es. « lo sto facendo », « già iniziato »).  
-   - Usa "done" solo se il nuovo memo dichiara esplicitamente che l’attività è completata.  
-   - Usa "not_required" se l’attività non è più necessaria.  
-   - Usa "cancelled" se l’attività non verrà svolta.  
-   - Se aggiorni un elemento già "done", mantieni "done" a meno che il nuovo memo non riapra chiaramente l’attività.  
+   - Default: "not_started".
+   - Usa "in_progress" solo se il nuovo memo indica chiaramente che l’attività è già in corso (es. « lo sto facendo », « già iniziato »).
+   - Usa "done" solo se il nuovo memo dichiara esplicitamente che l’attività è completata.
+   - Usa "cancelled" se l’attività non verrà svolta.
+   - Se aggiorni un elemento già "done", mantieni "done" a meno che il nuovo memo non riapra chiaramente l’attività.
 
 6) Tag  
    - Fornisci 1–3 tag brevi, tutti in minuscolo, nella lingua del memo (es. italiano: « salute », « scadenza », « monitoraggio »).  

--- a/app/src/main/resources/llm/schema/todo.json
+++ b/app/src/main/resources/llm/schema/todo.json
@@ -17,14 +17,28 @@
           "additionalProperties": false,
           "required": ["op", "text", "status", "tags"],
           "properties": {
-            "op": { "type": "string", "enum": ["add", "update"] },
-            "text": { "type": "string", "minLength": 1 },
+            "op": {
+              "type": "string",
+              "enum": ["add", "update"]
+            },
+            "id": {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9_-]+$",
+              "description": "Mandatory if op=update. Must be not used or empty if op=add."
+            },
+            "text": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Actionable description of the item."
+            },
             "status": {
               "type": "string",
-              "enum": ["not_started", "in_progress", "done", "not_required", "cancelled"]
+              "enum": ["not_started", "in_progress", "done", "cancelled"]
             },
             "tags": {
               "type": "array",
+              "minItems": 1,
+              "maxItems": 3,
               "items": {
                 "type": "string",
                 "pattern": "^[a-zàèéìòóùç ]+$"
@@ -32,7 +46,17 @@
             },
             "due_date": { "type": "string", "format": "date" },
             "event_date": { "type": "string", "format": "date" }
-          }
+          },
+          "allOf": [
+            {
+              "if": { "properties": { "op": { "const": "update" } } },
+              "then": { "required": ["id"] }
+            },
+            {
+              "if": { "properties": { "op": { "const": "add" } } },
+              "then": { "not": { "required": ["id"] } }
+            }
+          ]
         }
       }
     }

--- a/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
@@ -44,7 +44,7 @@ class MemoProcessorTest {
             .put("op", "add")
             .put("text", "todo updated")
             .put("status", "not_started")
-            .put("tags", JSONArray())
+            .put("tags", JSONArray().put("tag"))
         server.enqueue(MockResponse().setBody(completionTodo(todoItem)).setResponseCode(200))
         server.enqueue(MockResponse().setBody(completion("appointments updated")).setResponseCode(200))
         server.enqueue(MockResponse().setBody(completion("thoughts updated")).setResponseCode(200))
@@ -90,7 +90,7 @@ class MemoProcessorTest {
             .put("op", "add")
             .put("text", "second")
             .put("status", "not_started")
-            .put("tags", JSONArray())
+            .put("tags", JSONArray().put("tag"))
         server.enqueue(MockResponse().setBody(completion(item2)).setResponseCode(200))
         server.start()
 
@@ -106,7 +106,7 @@ class MemoProcessorTest {
             todo = "first",
             appointments = "",
             thoughts = "",
-            todoItems = listOf(TodoItem("first", "not_started", emptyList())),
+            todoItems = listOf(TodoItem("first", "not_started", listOf("tag"))),
             appointmentItems = emptyList(),
             thoughtItems = emptyList()
         )
@@ -120,8 +120,8 @@ class MemoProcessorTest {
 
         assertEquals(
             listOf(
-                TodoItem("first", "not_started", emptyList()),
-                TodoItem("second", "not_started", emptyList())
+                TodoItem("first", "not_started", listOf("tag")),
+                TodoItem("second", "not_started", listOf("tag"))
             ),
             summary.todoItems
         )
@@ -149,12 +149,12 @@ class MemoProcessorTest {
             .put("op", "add")
             .put("text", "first")
             .put("status", "not_started")
-            .put("tags", JSONArray())
+            .put("tags", JSONArray().put("tag"))
         val item2 = JSONObject()
             .put("op", "add")
             .put("text", "second")
             .put("status", "not_started")
-            .put("tags", JSONArray())
+            .put("tags", JSONArray().put("tag"))
         server.enqueue(MockResponse().setBody(completion(item1)).setResponseCode(200))
         server.enqueue(MockResponse().setBody(completion(item2)).setResponseCode(200))
         server.start()
@@ -172,8 +172,8 @@ class MemoProcessorTest {
 
         assertEquals(
             listOf(
-                TodoItem("first", "not_started", emptyList()),
-                TodoItem("second", "not_started", emptyList())
+                TodoItem("first", "not_started", listOf("tag")),
+                TodoItem("second", "not_started", listOf("tag"))
             ),
             summary.todoItems
         )
@@ -201,7 +201,7 @@ class MemoProcessorTest {
             .put("op", "add")
             .put("text", "x")
             .put("status", "not_started")
-            .put("tags", JSONArray())
+            .put("tags", JSONArray().put("tag"))
         server.enqueue(MockResponse().setBody(completion(dummy)).setResponseCode(200))
         server.start()
 
@@ -218,7 +218,7 @@ class MemoProcessorTest {
             todo = tricky,
             appointments = "",
             thoughts = "",
-            todoItems = listOf(TodoItem(tricky, "not_started", emptyList())),
+            todoItems = listOf(TodoItem(tricky, "not_started", listOf("tag"))),
             appointmentItems = emptyList(),
             thoughtItems = emptyList(),
         )
@@ -238,7 +238,7 @@ class MemoProcessorTest {
             val itemObj = JSONObject()
                 .put("text", tricky)
                 .put("status", "not_started")
-                .put("tags", JSONArray())
+                .put("tags", JSONArray().put("tag"))
             itemsArr.put(itemObj)
             put("items", itemsArr)
         }.toString()


### PR DESCRIPTION
## Summary
- add unique `id` field to to-do items and require it in JSON schema
- update repositories, processor, and UI to propagate item IDs
- clarify prompts in all languages to reference IDs and simplify status values

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.MemoProcessorTest"` *(fails: Could not determine the dependencies of task ':app:testDebugUnitTest'. Failed to install the following SDK components: platforms;android-34 Android SDK Platform 34)*
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.persistence.NoteRepositoryTest"` *(fails: Could not determine the dependencies of task ':app:testDebugUnitTest'. Failed to install the following SDK components: platforms;android-34 Android SDK Platform 34)*

------
https://chatgpt.com/codex/tasks/task_e_68c8077b6eb483258460c762dba558eb