### PR TITLE
Propagate Firestore IDs into todo items for LLM processing

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -186,7 +186,11 @@ fun DianaApp(repository: NoteRepository, memoRepository: MemoRepository) {
                 if (processThoughts) {
                     thoughtNotes = summary.thoughtItems.map { StructuredNote.Memo(it.text, it.tags) }
                 }
-                repository.saveSummary(summary, processTodos, processAppointments, processThoughts)
+                val saved = repository.saveSummary(summary, processTodos, processAppointments, processThoughts)
+                if (processTodos) {
+                    todoItems = saved.todoItems
+                }
+                processor.initialize(saved)
                 screen = Screen.List
             } catch (e: IOException) {
                 Log.e("DianaApp", "Error processing memo: ${e.message}", e)

--- a/app/src/test/java/li/crescio/penates/diana/persistence/NoteRepositoryTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/persistence/NoteRepositoryTest.kt
@@ -58,6 +58,33 @@ class NoteRepositoryTest {
     }
 
     @Test
+    fun saveSummary_generatesIdsForNewTodos() = runBlocking {
+        System.setProperty("net.bytebuddy.experimental", "true")
+        val file = createTempFile().toFile()
+        val firestore = mockk<FirebaseFirestore>()
+        val collection = mockk<CollectionReference>()
+        val document = mockk<DocumentReference>()
+
+        every { firestore.collection("notes") } returns collection
+        every { collection.add(any()) } returns Tasks.forResult(document)
+        every { document.id } returns "generated"
+
+        val repo = NoteRepository(firestore, file)
+        val summary = MemoSummary(
+            todo = "",
+            appointments = "",
+            thoughts = "",
+            todoItems = listOf(TodoItem("task", "not_started", emptyList())),
+            appointmentItems = emptyList(),
+            thoughtItems = emptyList()
+        )
+
+        val result = repo.saveSummary(summary)
+
+        assertEquals("generated", result.todoItems[0].id)
+    }
+
+    @Test
     fun loadNotes_mergesLocalAndRemote_removingDuplicates_andSortsDescending() = runBlocking {
         System.setProperty("net.bytebuddy.experimental", "true")
         val file = createTempFile().toFile()


### PR DESCRIPTION
## Summary
- Persist Firestore document IDs in todo items and return updated MemoSummary
- Resync processor and UI state with saved summary so future LLM calls include IDs
- Add regression test ensuring new todos receive generated IDs

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.persistence.NoteRepositoryTest" --console=plain` *(fails: Installed Build Tools revision 34.0.0 is corrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c81529cd808325b434765f225cf303