### PR TITLE
Allow selecting LLM model from settings

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -35,6 +35,7 @@ class MemoProcessor(
     private val apiKey: String,
     private val logger: LlmLogger,
     locale: Locale,
+    initialModel: String = DEFAULT_MODEL,
     private val baseUrl: String = loadResource("llm/base_url.txt").trim(),
     private val client: OkHttpClient = OkHttpClient.Builder()
         .connectTimeout(30, TimeUnit.SECONDS)
@@ -42,6 +43,17 @@ class MemoProcessor(
         .writeTimeout(60, TimeUnit.SECONDS)
         .build()
 ) {
+
+    companion object {
+        const val DEFAULT_MODEL = "mistralai/mistral-nemo"
+
+        val AVAILABLE_MODELS = listOf(
+            DEFAULT_MODEL,
+            "openrouter/sonoma-sky-alpha",
+            "qwen/qwen3-30b-a3b",
+            "openai/gpt-oss-120b",
+        )
+    }
 
     private var todo: String = ""
     private var todoItems: List<TodoItem> = emptyList()
@@ -51,6 +63,14 @@ class MemoProcessor(
     private var thoughtItems: List<Thought> = emptyList()
 
     private val prompts = Prompts.forLocale(locale)
+
+    var model: String = normalizeModel(initialModel)
+        set(value) {
+            field = normalizeModel(value)
+        }
+
+    private fun normalizeModel(value: String): String =
+        if (AVAILABLE_MODELS.contains(value)) value else DEFAULT_MODEL
 
     private val requestTemplate = loadResource("llm/request.json")
 
@@ -142,9 +162,11 @@ class MemoProcessor(
 
     private fun buildRequest(system: String, user: String, schema: String): String {
         val encoder = JsonStringEncoder.getInstance()
+        val escapedModel = String(encoder.quoteAsString(model))
         val escapedSystem = String(encoder.quoteAsString(system))
         val escapedUser = String(encoder.quoteAsString(user))
         return requestTemplate
+            .replace("{model}", escapedModel)
             .replace("{system}", escapedSystem)
             .replace("{user}", escapedUser)
             .replace("{schema}", schema)

--- a/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
@@ -1,24 +1,33 @@
 package li.crescio.penates.diana.ui
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Button
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.annotation.StringRes
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import li.crescio.penates.diana.R
+
+data class LlmModelOption(val id: String, @StringRes val labelResId: Int)
 
 @Composable
 fun SettingsScreen(
     processTodos: Boolean,
     processAppointments: Boolean,
     processThoughts: Boolean,
+    selectedModel: String,
+    llmModels: List<LlmModelOption>,
     onProcessTodosChange: (Boolean) -> Unit,
     onProcessAppointmentsChange: (Boolean) -> Unit,
     onProcessThoughtsChange: (Boolean) -> Unit,
+    onModelChange: (String) -> Unit,
     onClearTodos: () -> Unit,
     onClearAppointments: () -> Unit,
     onClearThoughts: () -> Unit,
@@ -64,6 +73,30 @@ fun SettingsScreen(
                 Text(stringResource(R.string.process_thoughts))
                 Spacer(modifier = Modifier.weight(1f))
                 Switch(checked = processThoughts, onCheckedChange = onProcessThoughtsChange)
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(stringResource(R.string.llm_model))
+            Spacer(modifier = Modifier.height(8.dp))
+            llmModels.forEach { option ->
+                val label = stringResource(option.labelResId)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .selectable(
+                            selected = option.id == selectedModel,
+                            onClick = { onModelChange(option.id) },
+                            role = Role.RadioButton
+                        )
+                        .padding(vertical = 4.dp)
+                ) {
+                    RadioButton(
+                        selected = option.id == selectedModel,
+                        onClick = null
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(label)
+                }
             }
             Spacer(modifier = Modifier.height(16.dp))
             Button(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,9 @@
     <string name="process_todo">Process to-dos</string>
     <string name="process_appointments">Process appointments</string>
     <string name="process_thoughts">Process thoughts</string>
+    <string name="llm_model">LLM model</string>
+    <string name="model_mistral_nemo">Mistral Nemo (default)</string>
+    <string name="model_sonoma_sky_alpha">Sonoma Sky Alpha</string>
+    <string name="model_qwen_a3b">Qwen3 30B A3B</string>
+    <string name="model_gpt_oss_120b">GPT-OSS 120B</string>
 </resources>

--- a/app/src/main/resources/llm/request.json
+++ b/app/src/main/resources/llm/request.json
@@ -1,5 +1,5 @@
 {
-  "model": "mistralai/mistral-nemo",
+  "model": "{model}",
   "messages": [
     {"role":"system","content":"{system}"},
     {"role":"user","content":"{user}"}


### PR DESCRIPTION
## Summary
- persist the chosen LLM model in `MainActivity` and push changes into the memo processor
- teach `MemoProcessor` to validate supported models and include the selected model in request payloads
- add a radio button selector and localized labels for the available models on the settings screen

## Testing
- ./gradlew --console=plain :app:testDebugUnitTest *(fails: requires Android SDK Platform 34 installation)*

------
https://chatgpt.com/codex/tasks/task_e_68c92144ff448325b0b48e720f177433