### PR TITLE
Add session data models and repository

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/session/Session.kt
+++ b/app/src/main/java/li/crescio/penates/diana/session/Session.kt
@@ -1,0 +1,20 @@
+package li.crescio.penates.diana.session
+
+/**
+ * Represents a saved conversation session.
+ */
+data class Session(
+    val id: String,
+    val name: String,
+    val settings: SessionSettings = SessionSettings(),
+)
+
+/**
+ * Controls what data should be persisted for a session and which LLM model to use.
+ */
+data class SessionSettings(
+    val saveTodos: Boolean = true,
+    val saveAppointments: Boolean = true,
+    val saveThoughts: Boolean = true,
+    val model: String = "",
+)

--- a/app/src/main/java/li/crescio/penates/diana/session/SessionRepository.kt
+++ b/app/src/main/java/li/crescio/penates/diana/session/SessionRepository.kt
@@ -1,0 +1,179 @@
+package li.crescio.penates.diana.session
+
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+import java.util.UUID
+import kotlin.text.Charsets
+
+class SessionRepository(private val filesDir: File) {
+    private val lock = Any()
+    private val sessionFile = File(filesDir, "sessions.json")
+    private val sessions = mutableListOf<Session>()
+    private var selectedSessionId: String? = null
+
+    init {
+        val state = loadFromDisk()
+        sessions.addAll(state.sessions)
+        selectedSessionId = state.selectedSessionId
+    }
+
+    fun list(): List<Session> = synchronized(lock) {
+        sessions.toList()
+    }
+
+    fun create(name: String, settings: SessionSettings): Session = synchronized(lock) {
+        val session = Session(UUID.randomUUID().toString(), name, settings)
+        sessions.add(session)
+        persistLocked()
+        session
+    }
+
+    fun update(session: Session): Session = synchronized(lock) {
+        val index = sessions.indexOfFirst { it.id == session.id }
+        require(index >= 0) { "Session not found: ${session.id}" }
+        sessions[index] = session
+        persistLocked()
+        session
+    }
+
+    fun delete(id: String): Boolean = synchronized(lock) {
+        val removed = sessions.removeAll { it.id == id }
+        if (removed && selectedSessionId == id) {
+            selectedSessionId = null
+        }
+        if (removed) {
+            persistLocked()
+        }
+        removed
+    }
+
+    fun getSelected(): Session? = synchronized(lock) {
+        val selectedId = selectedSessionId
+        if (selectedId == null) {
+            null
+        } else {
+            sessions.firstOrNull { it.id == selectedId }
+        }
+    }
+
+    fun setSelected(id: String?) = synchronized(lock) {
+        if (id == selectedSessionId) {
+            return
+        }
+        if (id != null && sessions.none { it.id == id }) {
+            throw IllegalArgumentException("Session not found: $id")
+        }
+        selectedSessionId = id
+        persistLocked()
+    }
+
+    private fun persistLocked() {
+        val payload = JSONObject()
+        val array = JSONArray()
+        sessions.forEach { session ->
+            array.put(session.toJson())
+        }
+        payload.put("sessions", array)
+        selectedSessionId?.let { payload.put("selectedSessionId", it) }
+        writeAtomically(payload.toString())
+    }
+
+    private fun Session.toJson(): JSONObject {
+        val obj = JSONObject()
+        obj.put("id", id)
+        obj.put("name", name)
+        obj.put("settings", settings.toJson())
+        return obj
+    }
+
+    private fun SessionSettings.toJson(): JSONObject {
+        val obj = JSONObject()
+        obj.put("saveTodos", saveTodos)
+        obj.put("saveAppointments", saveAppointments)
+        obj.put("saveThoughts", saveThoughts)
+        obj.put("model", model)
+        return obj
+    }
+
+    private fun loadFromDisk(): RepositoryState {
+        if (!sessionFile.exists()) {
+            return RepositoryState(emptyList(), null)
+        }
+
+        return try {
+            val contents = sessionFile.readText()
+            if (contents.isBlank()) {
+                RepositoryState(emptyList(), null)
+            } else {
+                parseState(JSONObject(contents))
+            }
+        } catch (_: Exception) {
+            RepositoryState(emptyList(), null)
+        }
+    }
+
+    private fun parseState(json: JSONObject): RepositoryState {
+        val sessionsArray = json.optJSONArray("sessions") ?: JSONArray()
+        val parsedSessions = mutableListOf<Session>()
+        for (i in 0 until sessionsArray.length()) {
+            val obj = sessionsArray.optJSONObject(i) ?: continue
+            val id = obj.optString("id", "")
+            val name = obj.optString("name", "")
+            if (id.isBlank() || name.isBlank()) continue
+            val settings = parseSettings(obj.optJSONObject("settings"))
+            parsedSessions += Session(id, name, settings)
+        }
+        val selectedIdRaw = json.optString("selectedSessionId", "")
+        val selectedId = if (selectedIdRaw.isBlank()) {
+            null
+        } else {
+            parsedSessions.firstOrNull { it.id == selectedIdRaw }?.id
+        }
+        return RepositoryState(parsedSessions, selectedId)
+    }
+
+    private fun parseSettings(obj: JSONObject?): SessionSettings {
+        if (obj == null) return SessionSettings()
+        return SessionSettings(
+            saveTodos = obj.optBoolean("saveTodos", true),
+            saveAppointments = obj.optBoolean("saveAppointments", true),
+            saveThoughts = obj.optBoolean("saveThoughts", true),
+            model = obj.optString("model", ""),
+        )
+    }
+
+    private fun writeAtomically(contents: String) {
+        val parent = sessionFile.parentFile ?: filesDir
+        if (!parent.exists() && !parent.mkdirs()) {
+            throw IOException("Unable to create directory: ${parent.absolutePath}")
+        }
+        val tmp = File.createTempFile("sessions", ".json.tmp", parent)
+        try {
+            tmp.writeText(contents, Charsets.UTF_8)
+            if (sessionFile.exists()) {
+                if (!tmp.renameTo(sessionFile)) {
+                    if (!sessionFile.delete() || !tmp.renameTo(sessionFile)) {
+                        tmp.copyTo(sessionFile, overwrite = true)
+                        tmp.delete()
+                    }
+                }
+            } else {
+                if (!tmp.renameTo(sessionFile)) {
+                    tmp.copyTo(sessionFile, overwrite = true)
+                    tmp.delete()
+                }
+            }
+        } finally {
+            if (tmp.exists()) {
+                tmp.delete()
+            }
+        }
+    }
+
+    private data class RepositoryState(
+        val sessions: List<Session>,
+        val selectedSessionId: String?,
+    )
+}


### PR DESCRIPTION
## Summary
- add data models for sessions and their settings
- implement a JSON-backed SessionRepository that persists sessions under filesDir and tracks the selected session

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain *(fails: missing Android SDK Platform 34 and Build-Tools 34)*

------
https://chatgpt.com/codex/tasks/task_e_68c96fd5e98883259bd178a74b7598c2