### PR TITLE
Persist session settings via SessionRepository

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/session/Session.kt
+++ b/app/src/main/java/li/crescio/penates/diana/session/Session.kt
@@ -13,8 +13,8 @@ data class Session(
  * Controls what data should be persisted for a session and which LLM model to use.
  */
 data class SessionSettings(
-    val saveTodos: Boolean = true,
-    val saveAppointments: Boolean = true,
-    val saveThoughts: Boolean = true,
+    val processTodos: Boolean = true,
+    val processAppointments: Boolean = true,
+    val processThoughts: Boolean = true,
     val model: String = "",
 )

--- a/app/src/main/java/li/crescio/penates/diana/session/SessionRepository.kt
+++ b/app/src/main/java/li/crescio/penates/diana/session/SessionRepository.kt
@@ -90,9 +90,9 @@ class SessionRepository(private val filesDir: File) {
 
     private fun SessionSettings.toJson(): JSONObject {
         val obj = JSONObject()
-        obj.put("saveTodos", saveTodos)
-        obj.put("saveAppointments", saveAppointments)
-        obj.put("saveThoughts", saveThoughts)
+        obj.put("processTodos", processTodos)
+        obj.put("processAppointments", processAppointments)
+        obj.put("processThoughts", processThoughts)
         obj.put("model", model)
         return obj
     }
@@ -136,10 +136,17 @@ class SessionRepository(private val filesDir: File) {
 
     private fun parseSettings(obj: JSONObject?): SessionSettings {
         if (obj == null) return SessionSettings()
+        fun JSONObject.optBooleanWithFallback(newKey: String, oldKey: String, default: Boolean): Boolean {
+            return if (has(newKey)) {
+                optBoolean(newKey, default)
+            } else {
+                optBoolean(oldKey, default)
+            }
+        }
         return SessionSettings(
-            saveTodos = obj.optBoolean("saveTodos", true),
-            saveAppointments = obj.optBoolean("saveAppointments", true),
-            saveThoughts = obj.optBoolean("saveThoughts", true),
+            processTodos = obj.optBooleanWithFallback("processTodos", "saveTodos", true),
+            processAppointments = obj.optBooleanWithFallback("processAppointments", "saveAppointments", true),
+            processThoughts = obj.optBooleanWithFallback("processThoughts", "saveThoughts", true),
             model = obj.optString("model", ""),
         )
     }


### PR DESCRIPTION
## Summary
- ensure MainActivity creates or selects an active session and passes it into the Compose tree
- update DianaApp to persist process flags and the selected model through SessionRepository instead of SharedPreferences
- rename SessionSettings flags to process* and adjust SessionRepository serialization with backward-compatible parsing

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain *(fails: missing Android SDK Platform 34)*

------
https://chatgpt.com/codex/tasks/task_e_68c97e6736ac8325b2fed21ed7da4285