### PR TITLE
Adjust session settings persistence and show session name in settings

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
@@ -3,6 +3,7 @@ package li.crescio.penates.diana.ui
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -14,15 +15,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import li.crescio.penates.diana.R
+import li.crescio.penates.diana.session.SessionSettings
 
 data class LlmModelOption(val id: String, @StringRes val labelResId: Int)
 
 @Composable
 fun SettingsScreen(
-    processTodos: Boolean,
-    processAppointments: Boolean,
-    processThoughts: Boolean,
-    selectedModel: String,
+    sessionName: String,
+    settings: SessionSettings,
     llmModels: List<LlmModelOption>,
     onProcessTodosChange: (Boolean) -> Unit,
     onProcessAppointmentsChange: (Boolean) -> Unit,
@@ -48,13 +48,20 @@ fun SettingsScreen(
                 .weight(1f)
                 .padding(horizontal = 16.dp)
         ) {
+            Text(
+                text = stringResource(R.string.editing_session, sessionName),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+            )
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(stringResource(R.string.process_todo))
                 Spacer(modifier = Modifier.weight(1f))
-                Switch(checked = processTodos, onCheckedChange = onProcessTodosChange)
+                Switch(checked = settings.processTodos, onCheckedChange = onProcessTodosChange)
             }
             Spacer(modifier = Modifier.height(8.dp))
             Row(
@@ -63,7 +70,7 @@ fun SettingsScreen(
             ) {
                 Text(stringResource(R.string.process_appointments))
                 Spacer(modifier = Modifier.weight(1f))
-                Switch(checked = processAppointments, onCheckedChange = onProcessAppointmentsChange)
+                Switch(checked = settings.processAppointments, onCheckedChange = onProcessAppointmentsChange)
             }
             Spacer(modifier = Modifier.height(8.dp))
             Row(
@@ -72,7 +79,7 @@ fun SettingsScreen(
             ) {
                 Text(stringResource(R.string.process_thoughts))
                 Spacer(modifier = Modifier.weight(1f))
-                Switch(checked = processThoughts, onCheckedChange = onProcessThoughtsChange)
+                Switch(checked = settings.processThoughts, onCheckedChange = onProcessThoughtsChange)
             }
             Spacer(modifier = Modifier.height(16.dp))
             Text(stringResource(R.string.llm_model))
@@ -84,14 +91,14 @@ fun SettingsScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .selectable(
-                            selected = option.id == selectedModel,
+                            selected = option.id == settings.model,
                             onClick = { onModelChange(option.id) },
                             role = Role.RadioButton
                         )
                         .padding(vertical = 4.dp)
                 ) {
                     RadioButton(
-                        selected = option.id == selectedModel,
+                        selected = option.id == settings.model,
                         onClick = null
                     )
                     Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="process_appointments">Process appointments</string>
     <string name="process_thoughts">Process thoughts</string>
     <string name="llm_model">LLM model</string>
+    <string name="editing_session">Editing context for %1$s</string>
     <string name="model_mistral_nemo">Mistral Nemo (default)</string>
     <string name="model_sonoma_sky_alpha">Sonoma Sky Alpha</string>
     <string name="model_qwen_a3b">Qwen3 30B A3B</string>


### PR DESCRIPTION
## Summary
- update `DianaApp` to accept an `onUpdateSession` callback and keep session settings sanitised locally before persisting
- pass the full `SessionSettings` object and current session name into `SettingsScreen` so the UI reflects the active context
- add a string resource for the session-context label shown in settings

## Testing
- ./gradlew --console=plain :app:testDebugUnitTest *(fails: Installed Build Tools revision 34.0.0 is corrupted in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c1735154832591b95228591e52eb