### PR TITLE
Add session management tabs with create, rename, and delete

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -34,4 +34,13 @@
     <string name="process_todo">Traiter les tâches</string>
     <string name="process_appointments">Traiter les rendez-vous</string>
     <string name="process_thoughts">Traiter les pensées</string>
+    <string name="add_session">Ajouter une session</string>
+    <string name="session_default_name">Session %1$d</string>
+    <string name="rename_session">Renommer la session</string>
+    <string name="delete_session">Supprimer la session</string>
+    <string name="session_name">Nom de la session</string>
+    <string name="delete_session_title">Supprimer la session</string>
+    <string name="delete_session_message">Voulez-vous vraiment supprimer %1$s ?</string>
+    <string name="session_actions">Options de session</string>
+    <string name="no_sessions">Aucune session</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -34,4 +34,13 @@
     <string name="process_todo">Elabora attività</string>
     <string name="process_appointments">Elabora appuntamenti</string>
     <string name="process_thoughts">Elabora pensieri</string>
+    <string name="add_session">Aggiungi sessione</string>
+    <string name="session_default_name">Sessione %1$d</string>
+    <string name="rename_session">Rinomina sessione</string>
+    <string name="delete_session">Elimina sessione</string>
+    <string name="session_name">Nome sessione</string>
+    <string name="delete_session_title">Elimina sessione</string>
+    <string name="delete_session_message">Sei sicuro di voler eliminare %1$s?</string>
+    <string name="session_actions">Opzioni sessione</string>
+    <string name="no_sessions">Nessuna sessione</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,4 +42,13 @@
     <string name="model_sonoma_sky_alpha">Sonoma Sky Alpha</string>
     <string name="model_qwen_a3b">Qwen3 30B A3B</string>
     <string name="model_gpt_oss_120b">GPT-OSS 120B</string>
+    <string name="add_session">Add session</string>
+    <string name="session_default_name">Session %1$d</string>
+    <string name="rename_session">Rename session</string>
+    <string name="delete_session">Delete session</string>
+    <string name="session_name">Session name</string>
+    <string name="delete_session_title">Delete session</string>
+    <string name="delete_session_message">Are you sure you want to delete %1$s?</string>
+    <string name="session_actions">Session options</string>
+    <string name="no_sessions">No sessions</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a top-level session tab bar for switching and managing sessions
- support creating new sessions from the UI using the repository and auto-selection
- add rename and delete actions with confirmation dialogs and localized strings

## Testing
- ./gradlew :app:lintDebug *(fails: unable to install Android SDK Build-Tools 34 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cabbe1e88325947cad3c189474fc