### PR TITLE
Refactor note collections under sessions

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt
+++ b/app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt
@@ -10,7 +10,7 @@ import java.io.File
 
 class NoteRepository(
     private val firestore: FirebaseFirestore,
-    private val collectionPath: String,
+    private val sessionId: String,
     private val file: File
 ) {
     suspend fun saveNotes(notes: List<StructuredNote>): List<StructuredNote> {
@@ -165,7 +165,10 @@ class NoteRepository(
         }
     }
 
-    private fun notesCollection() = firestore.collection(collectionPath)
+    private fun notesCollection() = firestore
+        .collection("sessions")
+        .document(sessionId)
+        .collection("notes")
 
     private fun noteKey(note: StructuredNote): String = when (note) {
         is StructuredNote.ToDo -> "todo:${note.id.ifBlank { note.text }}"

--- a/app/src/test/java/li/crescio/penates/diana/persistence/NoteRepositoryTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/persistence/NoteRepositoryTest.kt
@@ -20,7 +20,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import kotlin.io.path.createTempFile
 
-private const val COLLECTION_PATH = "sessions/test-session/notes"
+private const val SESSION_ID = "test-session"
 
 class NoteRepositoryTest {
 
@@ -29,13 +29,17 @@ class NoteRepositoryTest {
         System.setProperty("net.bytebuddy.experimental", "true")
         val file = createTempFile().toFile()
         val firestore = mockk<FirebaseFirestore>()
+        val sessionsCollection = mockk<CollectionReference>()
+        val sessionDocument = mockk<DocumentReference>()
         val collection = mockk<CollectionReference>()
         val document = mockk<DocumentReference>()
         val existingDocument = mockk<DocumentReference>()
 
         val capturedAdds = mutableListOf<Map<String, Any>>()
         val capturedSet = mutableListOf<Map<String, Any>>()
-        every { firestore.collection(COLLECTION_PATH) } returns collection
+        every { firestore.collection("sessions") } returns sessionsCollection
+        every { sessionsCollection.document(SESSION_ID) } returns sessionDocument
+        every { sessionDocument.collection("notes") } returns collection
         every { collection.add(any()) } answers {
             capturedAdds.add(firstArg())
             Tasks.forResult(document)
@@ -46,7 +50,7 @@ class NoteRepositoryTest {
             Tasks.forResult(null)
         }
 
-        val repo = NoteRepository(firestore, COLLECTION_PATH, file)
+        val repo = NoteRepository(firestore, SESSION_ID, file)
         val notes = listOf(
             StructuredNote.ToDo("task", status = "not_started", tags = listOf("home"), createdAt = 1L, id = "id1"),
             StructuredNote.Memo("memo", tags = listOf("x"), createdAt = 2L),
@@ -73,14 +77,18 @@ class NoteRepositoryTest {
         System.setProperty("net.bytebuddy.experimental", "true")
         val file = createTempFile().toFile()
         val firestore = mockk<FirebaseFirestore>()
+        val sessionsCollection = mockk<CollectionReference>()
+        val sessionDocument = mockk<DocumentReference>()
         val collection = mockk<CollectionReference>()
         val document = mockk<DocumentReference>()
 
-        every { firestore.collection(COLLECTION_PATH) } returns collection
+        every { firestore.collection("sessions") } returns sessionsCollection
+        every { sessionsCollection.document(SESSION_ID) } returns sessionDocument
+        every { sessionDocument.collection("notes") } returns collection
         every { collection.add(any()) } returns Tasks.forResult(document)
         every { document.id } returns "generated"
 
-        val repo = NoteRepository(firestore, COLLECTION_PATH, file)
+        val repo = NoteRepository(firestore, SESSION_ID, file)
         val summary = MemoSummary(
             todo = "",
             appointments = "",
@@ -107,13 +115,17 @@ class NoteRepositoryTest {
         file.writeText(localNotes.joinToString("\n") { JSONObject(expectedMap(it)).toString() })
 
         val firestore = mockk<FirebaseFirestore>()
+        val sessionsCollection = mockk<CollectionReference>()
+        val sessionDocument = mockk<DocumentReference>()
         val collection = mockk<CollectionReference>()
         val querySnapshot = mockk<QuerySnapshot>()
         val doc1 = mockk<DocumentSnapshot>(relaxed = true)
         val doc2 = mockk<DocumentSnapshot>(relaxed = true)
         val doc3 = mockk<DocumentSnapshot>(relaxed = true)
 
-        every { firestore.collection(COLLECTION_PATH) } returns collection
+        every { firestore.collection("sessions") } returns sessionsCollection
+        every { sessionsCollection.document(SESSION_ID) } returns sessionDocument
+        every { sessionDocument.collection("notes") } returns collection
         every { collection.get() } returns Tasks.forResult(querySnapshot)
         every { querySnapshot.documents } returns listOf(doc1, doc2, doc3)
 
@@ -141,7 +153,7 @@ class NoteRepositoryTest {
         every { doc3.getLong("createdAt") } returns 300L
         every { doc3.id } returns "id3"
 
-        val repo = NoteRepository(firestore, COLLECTION_PATH, file)
+        val repo = NoteRepository(firestore, SESSION_ID, file)
 
         val result = repo.loadNotes()
 
@@ -157,7 +169,7 @@ class NoteRepositoryTest {
     @Test
     fun summaryToNotes_mapsThoughtItems() {
         System.setProperty("net.bytebuddy.experimental", "true")
-        val repo = NoteRepository(mockk(), COLLECTION_PATH, createTempFile().toFile())
+        val repo = NoteRepository(mockk(), SESSION_ID, createTempFile().toFile())
 
         val summary = MemoSummary(
             todo = "",
@@ -204,7 +216,7 @@ class NoteRepositoryTest {
     @Test
     fun toJsonAndParse_roundTrip_returnsOriginalNote() {
         System.setProperty("net.bytebuddy.experimental", "true")
-        val repo = NoteRepository(mockk(), COLLECTION_PATH, createTempFile().toFile())
+        val repo = NoteRepository(mockk(), SESSION_ID, createTempFile().toFile())
 
         val toJson = NoteRepository::class.java.getDeclaredMethod("toJson", StructuredNote::class.java)
             .apply { isAccessible = true }
@@ -235,14 +247,18 @@ class NoteRepositoryTest {
         file.writeText(listOf(todo1, todo2, memo).joinToString("\n") { JSONObject(expectedMap(it)).toString() })
 
         val firestore = mockk<FirebaseFirestore>()
+        val sessionsCollection = mockk<CollectionReference>()
+        val sessionDocument = mockk<DocumentReference>()
         val collection = mockk<CollectionReference>()
         val docRef = mockk<DocumentReference>()
 
-        every { firestore.collection(COLLECTION_PATH) } returns collection
+        every { firestore.collection("sessions") } returns sessionsCollection
+        every { sessionsCollection.document(SESSION_ID) } returns sessionDocument
+        every { sessionDocument.collection("notes") } returns collection
         every { collection.document("id1") } returns docRef
         every { docRef.delete() } returns Tasks.forResult(null)
 
-        val repo = NoteRepository(firestore, COLLECTION_PATH, file)
+        val repo = NoteRepository(firestore, SESSION_ID, file)
 
         repo.deleteTodoItem("id1")
 
@@ -262,12 +278,16 @@ class NoteRepositoryTest {
         file.writeText(listOf(appt1, appt2, memo).joinToString("\n") { JSONObject(expectedMap(it)).toString() })
 
         val firestore = mockk<FirebaseFirestore>()
+        val sessionsCollection = mockk<CollectionReference>()
+        val sessionDocument = mockk<DocumentReference>()
         val collection = mockk<CollectionReference>()
         val querySnapshot = mockk<QuerySnapshot>()
         val doc = mockk<DocumentSnapshot>()
         val docRef = mockk<DocumentReference>()
 
-        every { firestore.collection(COLLECTION_PATH) } returns collection
+        every { firestore.collection("sessions") } returns sessionsCollection
+        every { sessionsCollection.document(SESSION_ID) } returns sessionDocument
+        every { sessionDocument.collection("notes") } returns collection
         every { collection.whereEqualTo("type", "event") } returns collection
         every { collection.whereEqualTo("text", "meet") } returns collection
         every { collection.whereEqualTo("datetime", "2024-05-01T10:00:00Z") } returns collection
@@ -277,7 +297,7 @@ class NoteRepositoryTest {
         every { doc.reference } returns docRef
         every { docRef.delete() } returns Tasks.forResult(null)
 
-        val repo = NoteRepository(firestore, COLLECTION_PATH, file)
+        val repo = NoteRepository(firestore, SESSION_ID, file)
 
         repo.deleteAppointment("meet", "2024-05-01T10:00:00Z", "office")
 


### PR DESCRIPTION
## Summary
- build Firestore note collections via the sessions/{sessionId}/notes hierarchy
- migrate legacy top-level notes into the default session when it is created
- adjust NoteRepository tests to mock the new Firestore path construction

## Testing
- `./gradlew :app:testDebugUnitTest --console=plain` *(fails: Android SDK Platform 34 installation error in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d4a7679c8325822aa6efb05f6f00