### PR TITLE
Use session-specific memo repository and migrate legacy memos

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/MemoArchiveScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/MemoArchiveScreen.kt
@@ -5,22 +5,29 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import li.crescio.penates.diana.R
 import li.crescio.penates.diana.notes.Memo
+import li.crescio.penates.diana.persistence.MemoRepository
 import li.crescio.penates.diana.player.Player
 
 @Composable
 fun MemoArchiveScreen(
-    memos: List<Memo>,
+    memoRepository: MemoRepository,
     player: Player,
     onBack: () -> Unit,
     onReprocess: (Memo) -> Unit
 ) {
+    var memos by remember(memoRepository) { mutableStateOf<List<Memo>>(emptyList()) }
+
+    LaunchedEffect(memoRepository) {
+        memos = memoRepository.loadMemos()
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier

--- a/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
@@ -23,9 +23,11 @@ import li.crescio.penates.diana.notes.Transcript
 import li.crescio.penates.diana.recorder.AndroidRecorder
 import li.crescio.penates.diana.transcriber.GroqTranscriber
 import li.crescio.penates.diana.R
+import li.crescio.penates.diana.persistence.MemoRepository
 
 @Composable
 fun RecorderScreen(
+    memoRepository: MemoRepository,
     logs: List<String>,
     addLog: (String) -> Unit,
     snackbarHostState: SnackbarHostState,
@@ -99,7 +101,9 @@ fun RecorderScreen(
                                 }
                             }
                         }
-                        onFinish(Memo(transcript?.text.orEmpty(), recording.filePath))
+                        val memo = Memo(transcript?.text.orEmpty(), recording.filePath)
+                        memoRepository.addMemo(memo)
+                        onFinish(memo)
                     }
                 },
                 enabled = isRecording


### PR DESCRIPTION
## Summary
- persist memo data in files named `memos_<sessionId>.txt` and move any legacy `memos.txt` data into the default session
- update `MemoArchiveScreen` to load its list from the injected session-aware `MemoRepository`
- ensure `RecorderScreen` writes new memos through the injected repository before delegating for processing

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.persistence.MemoRepositoryTest" --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68c9e160109c8325a74e7cf62dacac88