### PR TITLE
Fix session tab interactions and apply scaffold padding

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/MemoArchiveScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/MemoArchiveScreen.kt
@@ -20,6 +20,7 @@ fun MemoArchiveScreen(
     memoRepository: MemoRepository,
     player: Player,
     onBack: () -> Unit,
+    modifier: Modifier = Modifier,
     onReprocess: (Memo) -> Unit
 ) {
     var memos by remember(memoRepository) { mutableStateOf<List<Memo>>(emptyList()) }
@@ -28,7 +29,7 @@ fun MemoArchiveScreen(
         memos = memoRepository.loadMemos()
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/li/crescio/penates/diana/ui/ProcessingScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/ProcessingScreen.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun ProcessingScreen(status: String, messages: List<String>) {
-    Column(modifier = Modifier.fillMaxSize()) {
+fun ProcessingScreen(status: String, messages: List<String>, modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
                 .weight(1f)

--- a/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/RecorderScreen.kt
@@ -31,6 +31,7 @@ fun RecorderScreen(
     logs: List<String>,
     addLog: (String) -> Unit,
     snackbarHostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
     onFinish: (Memo) -> Unit
 ) {
     val context = LocalContext.current
@@ -73,7 +74,7 @@ fun RecorderScreen(
         }
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
                 .weight(1f)

--- a/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
@@ -32,8 +32,9 @@ fun SettingsScreen(
     onClearAppointments: () -> Unit,
     onClearThoughts: () -> Unit,
     onBack: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/li/crescio/penates/diana/ui/TextMemoScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/TextMemoScreen.kt
@@ -12,10 +12,10 @@ import androidx.compose.ui.res.stringResource
 import li.crescio.penates.diana.R
 
 @Composable
-fun TextMemoScreen(onSave: (String) -> Unit) {
+fun TextMemoScreen(modifier: Modifier = Modifier, onSave: (String) -> Unit) {
     var text by remember { mutableStateOf("") }
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
         TextField(
             value = text,
             onValueChange = { text = it },


### PR DESCRIPTION
## Summary
- ensure scaffold content padding is passed to every screen so the session tab bar no longer overlaps page content
- expose modifier parameters on settings, text memo, recorder, processing, and archive screens to honor the scaffold padding
- remove the blocking pointer input from the session tab so taps properly switch sessions while keeping the overflow menu accessible

## Testing
- `./gradlew :app:compileDebugKotlin --console=plain` *(fails: missing Android SDK Platform 34; zip extraction error)*

------
https://chatgpt.com/codex/tasks/task_e_68ca83f4ae4483258df1434cdc90db14