### PR TITLE
Update architecture doc for session-based flow

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,23 +1,44 @@
 # Architecture
 
-Diana records voice notes and transforms them into structured items. The
-application uses several modules:
+Diana captures spoken ideas and turns them into structured notes through a
+pipeline that is organized around per-session environments. Each session keeps
+its recordings, intermediate memos, and final notes isolated so that users can
+safely switch between topics without data leaking across sessions.
 
-- `recorder` captures audio from the device.
-- `transcriber` turns audio into text.
-- `llm` interprets transcripts into notes.
-- `persistence` stores notes locally and in Firebase.
-- `notes` defines core domain models.
-- `ui` presents a Compose based interface.
+## Recording and transcription
 
-The processing pipeline moves a recording through four ordered steps:
+`AndroidRecorder` runs on the device and streams audio into session-specific
+storage. The recorder hands the captured audio to `GroqTranscriber`, which
+invokes the Groq speech model and emits textual **memos** for the active
+session. These memos are appended to files such as `memos_{id}.txt`, making it
+possible to inspect the raw transcription history for any given session.
 
-1. **TranscriptionStep** converts audio clips into text.
-2. **InterpretationStep** calls the language model to build structured notes.
-3. **PersistenceStep** saves notes to Firestore and to a local file.
-4. **CallbackStep** reports progress back to the user interface.
+## Processing inside `DianaApp`
 
-Data flows from the microphone to persistent storage in the following order:
+`DianaApp` wires together the components that react to new memos. It constructs
+a session-scoped environment where `MemoProcessor` interprets each memo and
+updates the `NoteRepository`. The repository aggregates structured notes and
+keeps them synchronized between the local file (`sessions/{id}/notes.txt`) and
+Firestore (`sessions/{id}/notes`). The Compose UI that lives inside
+`DianaApp` observes repository flows, displays progress, and triggers actions
+such as retrying a transcription or opening a memo preview.
 
-recording → transcription → LLM processing → structured notes → persistence
-→ display.
+Per-session settings toggles (for example, whether to auto-archive processed
+memos or stream partial transcripts) are also owned by `DianaApp`. The app
+persists these user choices alongside the session so that the interface and the
+processing pipeline stay aligned.
+
+## Session management and isolation
+
+Session management is coordinated by `SessionRepository`, which collaborates
+with `createSessionEnvironment` to spin up an isolated set of storage
+locations, processors, and configuration for each active session. When a user
+switches sessions, the repository tears down the old environment and activates
+another one without cross-contamination of notes or preferences.
+
+By separating files under `sessions/{id}` and memo logs under `memos_{id}.txt`,
+the application keeps the file system cleanly partitioned. Firestore mirrors
+this structure by nesting documents under `sessions/{id}/notes`, ensuring that
+cloud synchronization respects the same boundaries. The Compose UI uses the
+session repository to route user actions and surface the correct data for the
+currently selected session.


### PR DESCRIPTION
## Summary
- rewrite the architecture guide around the memo-based AndroidRecorder and GroqTranscriber flow
- document how DianaApp orchestrates memo processing, repositories, and session isolation

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68cacf43d1888325b7d3af5a71d5ad33