### PR TITLE
Set API key environment variables for build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
       - name: Build
+        env:
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: ./gradlew assembleDebug
       - name: Firebase App Distribution
         if: success()


### PR DESCRIPTION
## Summary
- map GROQ and OpenRouter API keys from repository secrets into the Gradle build step

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cae70e8a748325b1e792c5dee9bfb7