### PR TITLE
Handle GROQ API key errors and add abort control to transcription

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,9 @@
     <string name="log_transcription_failed">Transcription failed</string>
     <string name="log_llm_failed">Processing failed</string>
     <string name="retry">Retry</string>
+    <string name="abort">Abort</string>
+    <string name="groq_api_key_missing">GROQ API key missing. Unable to transcribe recording.</string>
+    <string name="log_groq_api_key_missing">GROQ API key missing</string>
     <string name="api_key_missing">OpenRouter API key missing. Memo processing disabled.</string>
     <string name="clear_todo">Clear to-do list</string>
     <string name="clear_appointments">Clear appointments</string>


### PR DESCRIPTION
## Summary
- guard the Groq transcriber against missing API keys and return clearer error messages when requests fail
- add retry or abort dialog handling on transcription failures so users can stop the retry loop
- surface dedicated strings for the new abort action and missing Groq API key messaging

## Testing
- ./gradlew :app:lint *(fails: Build Tools 34.0.0 is missing AAPT in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68cae678316c83258766c81491102b8b