### PR TITLE
Add deletion flow for archived memos

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/persistence/MemoRepository.kt
+++ b/app/src/main/java/li/crescio/penates/diana/persistence/MemoRepository.kt
@@ -17,6 +17,28 @@ class MemoRepository(private val file: File) {
         return file.readLines().mapNotNull { parse(it) }
     }
 
+    suspend fun deleteMemo(memo: Memo) {
+        if (!file.exists()) return
+
+        val remaining = mutableListOf<String>()
+        var removed = false
+
+        file.readLines().forEach { line ->
+            val parsed = parse(line)
+            if (!removed && parsed != null && parsed.text == memo.text && parsed.audioPath == memo.audioPath) {
+                removed = true
+            } else {
+                remaining += line
+            }
+        }
+
+        if (remaining.isEmpty()) {
+            file.writeText("")
+        } else {
+            file.writeText(remaining.joinToString(separator = "\n", postfix = "\n"))
+        }
+    }
+
     private fun toJson(memo: Memo): String {
         val obj = JSONObject()
         obj.put("text", memo.text)

--- a/app/src/main/java/li/crescio/penates/diana/ui/MemoArchiveScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/MemoArchiveScreen.kt
@@ -1,20 +1,26 @@
 package li.crescio.penates.diana.ui
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import li.crescio.penates.diana.R
 import li.crescio.penates.diana.notes.Memo
 import li.crescio.penates.diana.persistence.MemoRepository
 import li.crescio.penates.diana.player.Player
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun MemoArchiveScreen(
     memoRepository: MemoRepository,
@@ -24,6 +30,8 @@ fun MemoArchiveScreen(
     onReprocess: (Memo) -> Unit
 ) {
     var memos by remember(memoRepository) { mutableStateOf<List<Memo>>(emptyList()) }
+    var memoPendingDeletion by remember { mutableStateOf<Memo?>(null) }
+    val scope = rememberCoroutineScope()
 
     LaunchedEffect(memoRepository) {
         memos = memoRepository.loadMemos()
@@ -45,6 +53,10 @@ fun MemoArchiveScreen(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .fillMaxWidth()
+                        .combinedClickable(
+                            onClick = {},
+                            onLongClick = { memoPendingDeletion = memo }
+                        )
                         .padding(vertical = 8.dp)
                 ) {
                     if (memo.audioPath != null) {
@@ -64,6 +76,33 @@ fun MemoArchiveScreen(
                 }
             }
         }
+    }
+
+    val memoToDelete = memoPendingDeletion
+    if (memoToDelete != null) {
+        AlertDialog(
+            onDismissRequest = { memoPendingDeletion = null },
+            title = { Text(stringResource(R.string.delete_memo_title)) },
+            text = { Text(stringResource(R.string.delete_memo_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        scope.launch {
+                            memoRepository.deleteMemo(memoToDelete)
+                            memos = memoRepository.loadMemos()
+                            memoPendingDeletion = null
+                        }
+                    }
+                ) {
+                    Text(stringResource(R.string.delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { memoPendingDeletion = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
     }
 }
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -43,4 +43,6 @@
     <string name="delete_session_message">Voulez-vous vraiment supprimer %1$s ?</string>
     <string name="session_actions">Options de session</string>
     <string name="no_sessions">Aucune session</string>
+    <string name="delete_memo_title">Supprimer le mémo</string>
+    <string name="delete_memo_message">Voulez-vous vraiment supprimer ce mémo ?</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -43,4 +43,6 @@
     <string name="delete_session_message">Sei sicuro di voler eliminare %1$s?</string>
     <string name="session_actions">Opzioni sessione</string>
     <string name="no_sessions">Nessuna sessione</string>
+    <string name="delete_memo_title">Elimina memo</string>
+    <string name="delete_memo_message">Sei sicuro di voler eliminare questo memo?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,4 +54,6 @@
     <string name="delete_session_message">Are you sure you want to delete %1$s?</string>
     <string name="session_actions">Session options</string>
     <string name="no_sessions">No sessions</string>
+    <string name="delete_memo_title">Delete memo</string>
+    <string name="delete_memo_message">Are you sure you want to delete this memo?</string>
 </resources>


### PR DESCRIPTION
## Summary
- add the ability to remove stored memos with a long-press confirmation dialog
- extend the memo repository with delete support and update localized strings

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain *(fails: Android SDK Build-Tools 34 is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb99d4d070832583992cd20f02a0f9