### PR TITLE
Add Firestore sync to session repository

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -69,14 +69,14 @@ import li.crescio.penates.diana.session.SessionSettings
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val sessionRepository = SessionRepository(filesDir)
+        val firestore = FirebaseFirestore.getInstance()
+        val sessionRepository = SessionRepository(filesDir, firestore)
         LlmResources.initialize(File(filesDir, "llm_resources"))
         val sessionInitialization = ensureInitialSession(sessionRepository)
         val permissionMessage =
             "Firestore PERMISSION_DENIED. Check security rules or authentication."
         FirebaseAuth.getInstance().signInAnonymously()
             .addOnSuccessListener {
-                val firestore = FirebaseFirestore.getInstance()
                 lifecycleScope.launch {
                     try {
                         LlmResources.refreshFromFirestore(firestore)


### PR DESCRIPTION
## Summary
- inject FirebaseFirestore into SessionRepository and coordinate async remote sync for creates, updates, deletions, imports, and selection changes
- add Firestore persistence helpers with structured logging, cascade delete of session notes, and graceful failure handling
- update MainActivity to share a single Firestore instance with the repository

## Testing
- `./gradlew :app:testDebugUnitTest --console=plain` *(fails: Installed Build Tools revision 34.0.0 is corrupted in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc092e6bbc8325a9af26163527c463