### PR TITLE
Add remote session import flow

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,4 +56,13 @@
     <string name="no_sessions">No sessions</string>
     <string name="delete_memo_title">Delete memo</string>
     <string name="delete_memo_message">Are you sure you want to delete this memo?</string>
+    <string name="import_remote_sessions">Import sessions</string>
+    <string name="import_remote_sessions_title">Import remote sessions</string>
+    <string name="no_remote_sessions">No remote sessions available.</string>
+    <string name="remote_session_settings">To-dos: %1$s • Appointments: %2$s • Thoughts: %3$s • Model: %4$s</string>
+    <string name="setting_enabled">On</string>
+    <string name="setting_disabled">Off</string>
+    <string name="remote_session_model_default">Default</string>
+    <string name="import_session_action">Import</string>
+    <string name="close">Close</string>
 </resources>


### PR DESCRIPTION
## Summary
- fetch remote sessions from Firestore after sign-in, backfill missing documents, and expose helpers for immediate sync
- surface importable sessions in the UI via a cloud tab action and dialog that shows remote settings and triggers imports
- add string resources for the new affordance and ensure create/rename/update operations push remote changes

## Testing
- ./gradlew --console=plain :app:compileDebugKotlin *(fails: missing Android SDK components in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc17cc2e4c8325b2719db6c2422092