### PR TITLE
Split session deletion into local and remote options

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,9 @@
     <string name="delete_session">Delete session</string>
     <string name="session_name">Session name</string>
     <string name="delete_session_title">Delete session</string>
-    <string name="delete_session_message">Are you sure you want to delete %1$s?</string>
+    <string name="delete_session_message">How would you like to delete %1$s?</string>
+    <string name="delete_session_local_action">Delete on this device</string>
+    <string name="delete_session_remote_action">Delete on this device and from Firebase</string>
     <string name="session_actions">Session options</string>
     <string name="no_sessions">No sessions</string>
     <string name="delete_memo_title">Delete memo</string>


### PR DESCRIPTION
## Summary
- add repository helpers to delete sessions locally or delete locally plus Firebase cleanup
- update the session tab dialog so users can choose between local-only or remote deletion
- clarify the delete-session copy and add action labels for the new commands

## Testing
- ./gradlew --console=plain :app:testDebugUnitTest *(fails: Android SDK Platform 34 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf29335e0c83258925c95fbb8d59e8