### PR TITLE
Add cancel option to LLM failure snackbar

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -419,6 +420,7 @@ fun DianaApp(
     val processingText = stringResource(R.string.processing)
     val logLlmFailed = stringResource(R.string.log_llm_failed)
     val retryLabel = stringResource(R.string.retry)
+    val cancelLabel = stringResource(R.string.cancel)
     val logApiKeyMissing = stringResource(R.string.api_key_missing)
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -550,7 +552,8 @@ fun DianaApp(
                 addLog("LLM error: ${e.message ?: e}")
                 val result = snackbarHostState.showSnackbar(
                     message = logLlmFailed,
-                    actionLabel = retryLabel
+                    actionLabel = retryLabel,
+                    withDismissAction = true
                 )
                 if (result == SnackbarResult.ActionPerformed) {
                     processMemo(memo)
@@ -583,7 +586,30 @@ fun DianaApp(
                 },
             )
         },
-        snackbarHost = { SnackbarHost(snackbarHostState) },
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState) { data ->
+                Snackbar(
+                    action = {
+                        data.visuals.actionLabel?.let { label ->
+                            TextButton(onClick = { data.performAction() }) {
+                                Text(label)
+                            }
+                        }
+                    },
+                    dismissAction = if (data.visuals.withDismissAction) {
+                        {
+                            TextButton(onClick = { data.dismiss() }) {
+                                Text(cancelLabel)
+                            }
+                        }
+                    } else {
+                        null
+                    }
+                ) {
+                    Text(data.visuals.message)
+                }
+            }
+        },
         bottomBar = {
             if (screen == Screen.List) {
                 NavigationBar {


### PR DESCRIPTION
## Summary
- add a cancel label alongside the retry option when LLM processing fails
- customize the snackbar host so dismissing explicitly returns to the main UI
- ensure the snackbar request asks for a dismiss action to surface the cancel button

## Testing
- `./gradlew --console=plain :app:compileDebugKotlin` *(fails: missing Android SDK Platform 34 due to FileAlreadyExistsException during installation)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb10d263083258f5bc9211776742f