### PR TITLE
Load LLM models from external resource file

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -50,6 +51,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.tasks.await
 import li.crescio.penates.diana.llm.LlmLogger
+import li.crescio.penates.diana.llm.LlmModelCatalog
 import li.crescio.penates.diana.llm.LlmResources
 import li.crescio.penates.diana.llm.MemoProcessor
 import li.crescio.penates.diana.llm.TodoItem
@@ -421,12 +423,33 @@ fun DianaApp(
     val retryLabel = stringResource(R.string.retry)
     val logApiKeyMissing = stringResource(R.string.api_key_missing)
     val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+    val modelOptions = remember(context) {
+        val resources = context.resources
+        val packageName = context.packageName
+        val options = LlmModelCatalog.availableModels().mapNotNull { definition ->
+            val resId = resources.getIdentifier(definition.labelResourceName, "string", packageName)
+            if (resId == 0) {
+                Log.w("MainActivity", "Missing string resource for model label ${definition.labelResourceName}")
+                null
+            } else {
+                LlmModelOption(definition.id, resId)
+            }
+        }
+        if (options.isEmpty()) {
+            listOf(LlmModelOption(MemoProcessor.DEFAULT_MODEL, R.string.model_mistral_nemo))
+        } else {
+            options
+        }
+    }
+    val availableModelIds = remember(modelOptions) { modelOptions.map { it.id } }
 
     fun sanitizeModel(model: String): String {
-        return if (model in MemoProcessor.AVAILABLE_MODELS) {
-            model
-        } else {
-            MemoProcessor.DEFAULT_MODEL
+        return when {
+            availableModelIds.isEmpty() -> MemoProcessor.DEFAULT_MODEL
+            availableModelIds.contains(model) -> model
+            availableModelIds.contains(MemoProcessor.DEFAULT_MODEL) -> MemoProcessor.DEFAULT_MODEL
+            else -> availableModelIds.first()
         }
     }
 
@@ -446,15 +469,6 @@ fun DianaApp(
             initialModel = sanitizedModel
         )
     }
-    val modelOptions = remember {
-        listOf(
-            LlmModelOption(MemoProcessor.DEFAULT_MODEL, R.string.model_mistral_nemo),
-            LlmModelOption("openrouter/sonoma-sky-alpha", R.string.model_sonoma_sky_alpha),
-            LlmModelOption("qwen/qwen3-30b-a3b", R.string.model_qwen_a3b),
-            LlmModelOption("openai/gpt-oss-120b", R.string.model_gpt_oss_120b),
-        )
-    }
-
     LaunchedEffect(session) {
         val sanitized = sanitizeModel(session.settings.model)
         val sanitizedSession = session.copy(settings = session.settings.copy(model = sanitized))

--- a/app/src/main/java/li/crescio/penates/diana/llm/LlmModelCatalog.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/LlmModelCatalog.kt
@@ -1,0 +1,84 @@
+package li.crescio.penates.diana.llm
+
+import android.util.Log
+import org.json.JSONArray
+import java.io.IOException
+import java.util.LinkedHashSet
+
+/**
+ * Loads the list of supported LLM models from bundled resources with optional
+ * overrides provided via [LlmResources].
+ */
+object LlmModelCatalog {
+    private const val TAG = "LlmModelCatalog"
+    private const val MODELS_PATH = "llm/models.json"
+
+    data class ModelDefinition(val id: String, val labelResourceName: String)
+
+    @Volatile
+    private var cachedRaw: String? = null
+
+    @Volatile
+    private var cachedModels: List<ModelDefinition> = emptyList()
+
+    /**
+     * Returns the ordered list of available models described by the catalog
+     * resource. Parsed definitions are cached and refreshed whenever the
+     * underlying resource content changes.
+     */
+    fun availableModels(): List<ModelDefinition> {
+        val raw = try {
+            LlmResources.load(MODELS_PATH)
+        } catch (e: IOException) {
+            Log.e(TAG, "Failed to load model catalog", e)
+            return cachedModels
+        }
+
+        if (cachedRaw == raw) {
+            return cachedModels
+        }
+
+        val parsed = parseModels(raw)
+        if (parsed == null) {
+            return cachedModels
+        }
+
+        cachedRaw = raw
+        cachedModels = parsed
+        return parsed
+    }
+
+    private fun parseModels(raw: String): List<ModelDefinition>? {
+        return try {
+            val result = mutableListOf<ModelDefinition>()
+            val seen = LinkedHashSet<String>()
+            val array = JSONArray(raw)
+            for (index in 0 until array.length()) {
+                val obj = array.optJSONObject(index)
+                if (obj == null) {
+                    Log.w(TAG, "Skipping model entry at index $index: not a JSON object")
+                    continue
+                }
+                val id = obj.optString("id").trim()
+                val label = obj.optString("label").trim()
+                if (id.isEmpty() || label.isEmpty()) {
+                    Log.w(TAG, "Skipping model entry at index $index: missing id or label")
+                    continue
+                }
+                if (!seen.add(id)) {
+                    Log.w(TAG, "Skipping duplicate model id '$id'")
+                    continue
+                }
+                result.add(ModelDefinition(id, label))
+            }
+            result
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse model catalog", e)
+            null
+        }
+    }
+
+    fun availableModelIds(): List<String> = availableModels().map { it.id }
+
+    fun isModelAvailable(id: String): Boolean = availableModels().any { it.id == id }
+}

--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -42,13 +42,6 @@ class MemoProcessor(
 
     companion object {
         const val DEFAULT_MODEL = "mistralai/mistral-nemo"
-
-        val AVAILABLE_MODELS = listOf(
-            DEFAULT_MODEL,
-            "openrouter/sonoma-sky-alpha",
-            "qwen/qwen3-30b-a3b",
-            "openai/gpt-oss-120b",
-        )
     }
 
     private var todo: String = ""
@@ -65,8 +58,17 @@ class MemoProcessor(
             field = normalizeModel(value)
         }
 
-    private fun normalizeModel(value: String): String =
-        if (AVAILABLE_MODELS.contains(value)) value else DEFAULT_MODEL
+    private fun normalizeModel(value: String): String {
+        val available = LlmModelCatalog.availableModelIds()
+        if (available.isEmpty()) {
+            return DEFAULT_MODEL
+        }
+        return when {
+            available.contains(value) -> value
+            available.contains(DEFAULT_MODEL) -> DEFAULT_MODEL
+            else -> available.first()
+        }
+    }
 
     private val requestTemplate = loadResource("llm/request.json")
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,6 @@
     <string name="llm_model">LLM model</string>
     <string name="editing_session">Editing context for %1$s</string>
     <string name="model_mistral_nemo">Mistral Nemo (default)</string>
-    <string name="model_sonoma_sky_alpha">Sonoma Sky Alpha</string>
     <string name="model_qwen_a3b">Qwen3 30B A3B</string>
     <string name="model_gpt_oss_120b">GPT-OSS 120B</string>
     <string name="add_session">Add session</string>

--- a/app/src/main/resources/llm/models.json
+++ b/app/src/main/resources/llm/models.json
@@ -1,0 +1,5 @@
+[
+  { "id": "mistralai/mistral-nemo", "label": "model_mistral_nemo" },
+  { "id": "qwen/qwen3-30b-a3b", "label": "model_qwen_a3b" },
+  { "id": "openai/gpt-oss-120b", "label": "model_gpt_oss_120b" }
+]


### PR DESCRIPTION
## Summary
- add an LLM model catalog that reads llm/models.json so the model list can be updated from Firestore
- update MemoProcessor and MainActivity to consume the dynamic catalog and drop the Sonoma Sky Alpha model
- create the llm/models.json resource and remove the unused Sonoma Sky Alpha string resource

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: Installed Build Tools revision 34.0.0 is corrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb1cb9fbc8325aa00463a98b3f5d1