### PR TITLE
Sketch thought document domain model

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -20,6 +20,7 @@ import java.time.LocalDate
 import java.util.concurrent.TimeUnit
 import kotlin.collections.ArrayDeque
 import android.util.Log
+import li.crescio.penates.diana.notes.ThoughtDocument
 
 private fun loadResource(path: String): String = LlmResources.load(path)
 
@@ -328,7 +329,8 @@ data class MemoSummary(
     val thoughts: String,
     val todoItems: List<TodoItem>,
     val appointmentItems: List<Appointment>,
-    val thoughtItems: List<Thought>
+    val thoughtItems: List<Thought>,
+    val thoughtDocument: ThoughtDocument? = null,
 )
 
 data class Thought(val text: String, val tags: List<String>)

--- a/app/src/main/java/li/crescio/penates/diana/notes/ThoughtDocument.kt
+++ b/app/src/main/java/li/crescio/penates/diana/notes/ThoughtDocument.kt
@@ -1,0 +1,28 @@
+package li.crescio.penates.diana.notes
+
+/**
+ * Represents a rich document for a group of thoughts. The markdown body stores the
+ * full rendered text while the outline contains the hierarchical headings that can
+ * be used to render navigation controls in the UI.
+ */
+data class ThoughtDocument(
+    val markdownBody: String,
+    val outline: ThoughtOutline = ThoughtOutline.EMPTY,
+)
+
+/** Outline metadata extracted from a [ThoughtDocument]'s markdown body. */
+data class ThoughtOutline(
+    val sections: List<ThoughtOutlineSection>,
+) {
+    companion object {
+        val EMPTY = ThoughtOutline(emptyList())
+    }
+}
+
+/** A heading within the markdown document. */
+data class ThoughtOutlineSection(
+    val title: String,
+    val level: Int,
+    val anchor: String,
+    val children: List<ThoughtOutlineSection> = emptyList(),
+)

--- a/docs/thoughts/thought-document-plan.md
+++ b/docs/thoughts/thought-document-plan.md
@@ -1,0 +1,49 @@
+# Thought document refactor plan
+
+## Domain model sketch
+- Introduce a `ThoughtDocument` domain model composed of
+  - `markdownBody`: the canonical markdown representation of the processed thoughts.
+  - `outline`: a `ThoughtOutline` structure that captures the hierarchical headings
+    to build navigation controls (chapter/section buttons) in the UI.
+- `ThoughtOutline` is a thin wrapper around the ordered list of `ThoughtOutlineSection`
+  entries. Each section exposes
+  - `title`: heading text rendered in the outline.
+  - `level`: markdown heading depth to keep nesting information.
+  - `anchor`: slug/id generated from the heading for deep linking.
+  - `children`: optional nested sections when the LLM emits sub-headings.
+- The new data classes live beside the existing note models so they can be reused
+  by memo/notes features and persisted independently of the raw LLM summary.
+
+## MemoSummary integration points
+- `MemoSummary` now exposes an optional `thoughtDocument` alongside the existing
+  string buffers and structured items so downstream components can opt-in to the
+  richer document when it becomes available.
+- `MemoProcessor.initialize` and `MemoProcessor.process` continue to hydrate the
+  legacy `thoughts` buffer today but will populate `thoughtDocument` once the
+  LLM prompt/output is updated.
+- `MainActivity.syncProcessor` and `MainActivity.processMemo` currently assemble
+  the `MemoSummary` that seeds or reacts to processing; both call sites will need
+  to supply or consume a `ThoughtDocument` instead of synthesizing a newline-
+  delimited string when the new flow is ready.
+- `NoteRepository.saveSummary`/`summaryToNotes` persist structured notes derived
+  from the summary. They will eventually need to persist the markdown body and
+  outline metadata in addition to individual memo notes.
+
+## Call sites assuming the simple string buffer
+To keep the follow-up implementation focused, the following code paths and tests
+still operate on the newline-delimited `thoughts` string and will need updates:
+- `MemoProcessor` maintains the running `thoughts` buffer, updates it through the
+  `updateBuffer` helper, persists it via `thoughtPriorJson`, and exposes it in
+  `MemoSummary`. (`app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt`)
+- `MainActivity.syncProcessor` builds `thoughts` with `joinToString("\n")` and
+  reads `summary.thoughts` when synchronizing processor state. It also maps the
+  returned `summary.thoughtItems` back into UI notes. (`app/src/main/java/li/crescio/penates/diana/MainActivity.kt`)
+- `NoteRepository.summaryToNotes` converts `summary.thoughtItems` into persisted
+  memo records while ignoring richer document metadata; persistence helpers like
+  `noteToMap`/`parse` expect flat text fields. (`app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt`)
+- Tests rely on the plain string contract:
+  - `MemoProcessorTest` asserts on `summary.thoughts` contents and seeds
+    initialization with simple strings.
+  - `NoteRepositoryTest` constructs `MemoSummary` instances with raw `thoughts`
+    strings when exercising persistence helpers.
+  (under `app/src/test/java/li/crescio/penates/diana/...`)


### PR DESCRIPTION
## Summary
- add ThoughtDocument domain classes that model the markdown body and outline metadata for processed thoughts
- extend MemoSummary to surface an optional ThoughtDocument so downstream components can adopt the richer payload
- document the upcoming refactor plan and note every touchpoint that still depends on the newline-delimited thoughts buffer

## Testing
- not run (documentation and data-class only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d0df51fd348325a3c0939da479f869