### PR TITLE
feat: parse thought markdown documents from LLM

### DIFF
--- a/app/src/main/resources/llm/prompts/en/thoughts.txt
+++ b/app/src/main/resources/llm/prompts/en/thoughts.txt
@@ -1,1 +1,1 @@
-thoughts and notes
+thoughts and notes. Produce a full markdown document in "updated_markdown" plus an outline "sections" array with "title", "level", "anchor", and "children" aligned to the markdown headings.

--- a/app/src/main/resources/llm/prompts/fr/thoughts.txt
+++ b/app/src/main/resources/llm/prompts/fr/thoughts.txt
@@ -1,1 +1,1 @@
-pensées et notes
+pensées et notes. Produis un document Markdown complet dans "updated_markdown" ainsi qu'un plan "sections" avec "title", "level", "anchor" et "children" correspondant aux titres du Markdown.

--- a/app/src/main/resources/llm/prompts/it/thoughts.txt
+++ b/app/src/main/resources/llm/prompts/it/thoughts.txt
@@ -1,1 +1,1 @@
-pensieri e note
+pensieri e note. Produci un documento Markdown completo in "updated_markdown" e un sommario "sections" con "title", "level", "anchor" e "children" allineati alle intestazioni del Markdown.

--- a/app/src/main/resources/llm/schema/thought.json
+++ b/app/src/main/resources/llm/schema/thought.json
@@ -3,7 +3,11 @@
   "schema": {
     "type": "object",
     "properties": {
-      "updated": { "type": "string" },
+      "updated_markdown": { "type": "string" },
+      "sections": {
+        "type": "array",
+        "items": { "$ref": "#/$defs/section" }
+      },
       "items": {
         "type": "array",
         "items": {
@@ -19,7 +23,22 @@
         }
       }
     },
-    "required": ["updated", "items"]
+    "required": ["updated_markdown", "sections", "items"],
+    "$defs": {
+      "section": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "level": { "type": "integer" },
+          "anchor": { "type": "string" },
+          "children": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/section" }
+          }
+        },
+        "required": ["title", "level", "anchor", "children"]
+      }
+    }
   },
   "strict": true
 }


### PR DESCRIPTION
## Summary
- update the thoughts prompt schema to request markdown output alongside outline metadata
- extend `MemoProcessor` to persist `ThoughtDocument` data and surface anchors in summaries
- expand the processor tests to validate the markdown contract and outline parsing

## Testing
- ./gradlew --no-daemon --console=plain :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.MemoProcessorTest" *(fails: Android SDK Platform 34 install conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e0cdb8d88325ae7845634b771954