### PR TITLE
Revamp thought navigation UI with markdown viewer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-auth-ktx'
     implementation 'com.google.firebase:firebase-firestore-ktx'
+    implementation 'io.noties.markwon:core:4.6.2'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'io.mockk:mockk:1.12.3'
     testImplementation 'org.json:json:20210307'

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,9 @@
     <string name="appointments">Appointments</string>
     <string name="thoughts_notes">Thoughts &amp; Notes</string>
     <string name="filter_tag">Filter by tag</string>
+    <string name="thoughts_outline_missing">No structured thought document available yet. Process a memo to generate one.</string>
+    <string name="thoughts_outline_no_match">No sections match the selected tag.</string>
+    <string name="thoughts_tags_label">Tags</string>
     <string name="back">Back</string>
     <string name="play">Play</string>
     <string name="reprocess">Reprocess</string>


### PR DESCRIPTION
## Summary
- add a markdown rendering dependency to the app module
- retain the processed ThoughtDocument in MainActivity and pass it into the list screen
- redesign the thoughts section into an outline navigator plus markdown viewer while preserving tag filtering

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: missing Android SDK Platform 34 in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e6d754b4832582d7d6f7224c5ed4