### PR TITLE
Document thought document flow and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Diana
+
+Diana turns spoken or written memos into structured todos, appointments, and
+thought documents that stay in sync across local storage and Firestore. The app
+ships with a Markdown-based thought reader so longer reflections remain easy to
+scan and navigate. 【F:app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt†L54-L120】【F:app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt†L45-L215】
+
+## Thought document viewer
+
+1. **Capture or type a memo.** Recording or typing in the Text Memo screen feeds
+   the memo to `MemoProcessor`, which asks the LLM to emit an updated Markdown
+   body plus an outline describing each heading. 【F:app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt†L361-L399】
+2. **Open the Notes tab.** The Thoughts card shows the outline as nested chips;
+   tap any heading to load just that section in the Markdown pane and filter by
+   tag to jump to relevant paragraphs. 【F:app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt†L160-L215】
+3. **Resume later on any device.** The Markdown body lives in `thoughts.md` and
+   its outline in `thought_outline.json`, both synced under the
+   `__thought_document__` document for the session so the reader is portable.
+   【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L19-L119】【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L236-L275】
+
+### Locale support
+
+The viewer reuses locale-specific prompts for English, Italian, and French. Set
+Android’s language before processing a memo and the app will fetch the matching
+prompt bundle automatically, producing Markdown that respects local phrasing and
+headings. 【F:app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt†L382-L413】
+
+### Troubleshooting
+
+* If no structured outline exists yet, the Thoughts card falls back to showing
+  tagged memo snippets until the first Markdown document is generated.
+  【F:app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt†L62-L141】
+* Clearing thoughts from Settings removes the cached Markdown/outline files; the
+  next processed memo will rebuild them from scratch. 【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L248-L275】

--- a/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt
@@ -15,7 +15,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import li.crescio.penates.diana.R
@@ -191,6 +195,7 @@ private fun ThoughtsSection(
                 modifier = Modifier
                     .weight(0.65f)
                     .fillMaxHeight()
+                    .testTag("thought-markdown")
             )
         }
 
@@ -264,7 +269,8 @@ private fun MarkdownViewer(
     val context = LocalContext.current
     val markwon = remember(context) { Markwon.builder(context).build() }
     AndroidView(
-        modifier = modifier,
+        modifier = modifier
+            .semantics { this.text = AnnotatedString(markdown) },
         factory = { ctx ->
             ScrollView(ctx).apply {
                 isFillViewport = true
@@ -312,7 +318,7 @@ private fun flattenOutline(
     return items
 }
 
-private data class SectionTagIndex(
+internal data class SectionTagIndex(
     val anchorTags: Map<String, Set<String>>,
     val titleTags: Map<String, Set<String>>,
     val freeTags: Set<String>,
@@ -324,13 +330,13 @@ private data class SectionTagIndex(
     }
 }
 
-private fun SectionTagIndex.tagsFor(section: ThoughtOutlineSection): Set<String> {
+internal fun SectionTagIndex.tagsFor(section: ThoughtOutlineSection): Set<String> {
     anchorTags[section.anchor]?.takeIf { it.isNotEmpty() }?.let { return it }
     titleTags[section.title]?.takeIf { it.isNotEmpty() }?.let { return it }
     return emptySet()
 }
 
-private fun buildSectionTagIndex(notes: List<StructuredNote>): SectionTagIndex {
+internal fun buildSectionTagIndex(notes: List<StructuredNote>): SectionTagIndex {
     val anchorTags = mutableMapOf<String, MutableSet<String>>()
     val titleTags = mutableMapOf<String, MutableSet<String>>()
     val freeTags = mutableSetOf<String>()
@@ -364,7 +370,7 @@ private fun buildSectionTagIndex(notes: List<StructuredNote>): SectionTagIndex {
     )
 }
 
-private fun extractSectionMarkdown(
+internal fun extractSectionMarkdown(
     markdown: String,
     section: ThoughtOutlineSection,
 ): String {

--- a/app/src/test/java/li/crescio/penates/diana/ui/NotesListScreenTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/ui/NotesListScreenTest.kt
@@ -1,11 +1,20 @@
 package li.crescio.penates.diana.ui
 
 import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
 import li.crescio.penates.diana.llm.TodoItem
+import li.crescio.penates.diana.notes.ThoughtDocument
+import li.crescio.penates.diana.notes.ThoughtOutline
+import li.crescio.penates.diana.notes.ThoughtOutlineSection
 import org.junit.Rule
 import org.junit.Test
 import org.junit.Assert.assertTrue
@@ -46,5 +55,76 @@ class NotesListScreenTest {
             .fetchSemanticsNode()
             .config[SemanticsProperties.Text].first()
         assertTrue(annotated.spanStyles.any { it.item.textDecoration == TextDecoration.LineThrough })
+    }
+
+    @Test
+    fun thoughtOutline_updatesMarkdownOnSelection() {
+        val markdown = """
+            # Overview
+
+            Intro details.
+
+            ## Deep Dive
+
+            More details.
+
+            # Next Steps
+
+            What to do.
+        """.trimIndent()
+        val document = ThoughtDocument(
+            markdownBody = markdown,
+            outline = ThoughtOutline(
+                listOf(
+                    ThoughtOutlineSection(
+                        title = "Overview",
+                        level = 1,
+                        anchor = "overview",
+                        children = listOf(
+                            ThoughtOutlineSection("Deep Dive", 2, "deep-dive")
+                        ),
+                    ),
+                    ThoughtOutlineSection("Next Steps", 1, "next-steps"),
+                )
+            )
+        )
+
+        composeTestRule.setContent {
+            NotesListScreen(
+                todoItems = emptyList(),
+                appointments = emptyList(),
+                notes = emptyList(),
+                thoughtDocument = document,
+                logs = emptyList(),
+                showTodos = false,
+                showAppointments = false,
+                showThoughts = true,
+                onTodoCheckedChange = { _, _ -> },
+                onTodoDelete = {},
+                onAppointmentDelete = {},
+            )
+        }
+
+        val markdownNode = composeTestRule.onNodeWithTag("thought-markdown")
+        markdownNode.assertExists()
+        markdownNode.assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.Text,
+                listOf(
+                    AnnotatedString(
+                        "# Overview\n\nIntro details.\n\n## Deep Dive\n\nMore details."
+                    )
+                )
+            )
+        )
+
+        composeTestRule.onNodeWithText("Next Steps").performClick()
+
+        markdownNode.assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.Text,
+                listOf(AnnotatedString("# Next Steps\n\nWhat to do."))
+            )
+        )
     }
 }

--- a/app/src/test/java/li/crescio/penates/diana/ui/ThoughtsSectionUtilsTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/ui/ThoughtsSectionUtilsTest.kt
@@ -1,0 +1,64 @@
+package li.crescio.penates.diana.ui
+
+import li.crescio.penates.diana.notes.StructuredNote
+import li.crescio.penates.diana.notes.ThoughtOutlineSection
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ThoughtsSectionUtilsTest {
+    @Test
+    fun extractSectionMarkdown_returnsSectionWithNestedContent() {
+        val markdown = """
+            # One
+
+            Intro
+
+            ## Detail
+
+            More info.
+
+            # Two
+
+            Follow up.
+        """.trimIndent()
+        val section = ThoughtOutlineSection("One", 1, "one")
+
+        val result = extractSectionMarkdown(markdown, section)
+
+        assertEquals(
+            "# One\n\nIntro\n\n## Detail\n\nMore info.",
+            result
+        )
+    }
+
+    @Test
+    fun buildSectionTagIndex_prioritizesAnchorsAndAggregatesTags() {
+        val notes = listOf(
+            StructuredNote.Memo(
+                text = "Anchor note",
+                tags = listOf("anchor"),
+                sectionAnchor = "intro",
+                sectionTitle = "Intro",
+            ),
+            StructuredNote.Memo(
+                text = "Title note",
+                tags = listOf("title"),
+                sectionTitle = "Intro",
+            ),
+            StructuredNote.Free(
+                text = "Loose",
+                tags = listOf("free"),
+            ),
+        )
+
+        val index = buildSectionTagIndex(notes)
+
+        val anchorTags = index.tagsFor(ThoughtOutlineSection("Intro", 1, "intro"))
+        assertEquals(setOf("anchor"), anchorTags)
+
+        val fallbackTags = index.tagsFor(ThoughtOutlineSection("Intro", 1, "missing"))
+        assertEquals(setOf("title"), fallbackTags)
+
+        assertEquals(setOf("anchor", "title", "free"), index.allTags)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,6 +28,23 @@ memos or stream partial transcripts) are also owned by `DianaApp`. The app
 persists these user choices alongside the session so that the interface and the
 processing pipeline stay aligned.
 
+### Thought document pipeline
+
+When the user enables thought processing, `MemoProcessor` asks the LLM for a
+full Markdown document plus a machine-readable outline. It stores the result as
+`ThoughtDocument`, exposing both the markdown body and nested sections to the
+rest of the app. 【F:app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt†L54-L120】【F:app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt†L361-L399】
+
+`NoteRepository` persists the markdown to disk alongside a JSON outline file and
+mirrors both artifacts to Firestore. Loading prefers local files but backfills
+from the remote copy so the Markdown viewer stays portable between devices.
+【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L19-L119】【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L236-L275】
+
+`NotesListScreen` turns the outline into nested chips and renders the selected
+section with Markwon. Users can filter sections by tag, and when no thought
+document exists the UI falls back to raw memo notes to keep the space useful.
+【F:app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt†L45-L215】【F:app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt†L265-L338】
+
 ## Session management and isolation
 
 Session management is coordinated by `SessionRepository`, which collaborates

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -12,7 +12,8 @@ Each subtype carries a small, well-defined set of fields:
 
 - **ToDo** — `text`, `status`, `tags`, `dueDate`, `eventDate`, `createdAt`, and
   an `id` (blank until a Firestore document assigns one). 【F:app/src/main/java/li/crescio/penates/diana/notes/Models.kt†L14-L23】
-- **Memo** — `text`, `tags`, and `createdAt`. 【F:app/src/main/java/li/crescio/penates/diana/notes/Models.kt†L25-L30】
+- **Memo** — `text`, `tags`, optional `sectionAnchor`/`sectionTitle`, and `createdAt`.
+  【F:app/src/main/java/li/crescio/penates/diana/notes/Models.kt†L25-L32】
 - **Event** — `text`, `datetime`, `location`, and `createdAt`. 【F:app/src/main/java/li/crescio/penates/diana/notes/Models.kt†L32-L37】
 - **Free** — `text`, `tags`, and `createdAt`. 【F:app/src/main/java/li/crescio/penates/diana/notes/Models.kt†L39-L44】
 
@@ -36,3 +37,22 @@ local and remote records, again honoring the stored timestamps. 【F:app/src/mai
 
 Todo items can therefore round-trip through Firestore, pick up their document
 IDs, and return to the client with the original creation time intact. 【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L16-L77】
+
+## Thought documents
+
+`MemoProcessor` now asks the LLM for a Markdown body and hierarchical outline
+whenever thoughts are processed. The resulting `ThoughtDocument` keeps the
+markdown plus parsed sections so downstream consumers can navigate headings and
+tags without reparsing the raw text. 【F:app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt†L54-L120】【F:app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt†L361-L399】
+
+`NoteRepository` persists the Markdown to `thoughts.md` and the outline to
+`thought_outline.json`, mirroring the same structure to Firestore under the
+`__thought_document__` sentinel document. Loading prefers the cached files but
+falls back to Firestore so the viewer stays in sync across devices. Clearing the
+thoughts category removes both the per-note memos and these document artifacts.
+【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L19-L119】【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L236-L275】
+
+`NotesListScreen` renders the outline as nested chips and feeds the selected
+section into a Markdown viewer backed by Markwon. The semantics tag mirrors the
+raw markdown so Compose tests can assert on navigation, and when no document is
+available the screen falls back to displaying tagged memos. 【F:app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt†L45-L215】【F:app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt†L265-L338】


### PR DESCRIPTION
## Summary
- expose markdown viewer semantics and navigation helpers so tests can assert the rendered section
- add unit coverage for outline parsing plus a Robolectric compose test that exercises thought-section navigation
- document the thought document pipeline and publish a user how-to for the markdown reader

## Testing
- `./gradlew :app:testDebugUnitTest --console=plain` *(fails: existing NoteRepository.kt parse error present on main)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ec1a3a8c83259cec627bcd553be2