### PR TITLE
Update AGENTS orientation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,17 @@
 # AGENTS Instructions
 
+## Getting oriented
+- **app** – Android client source. The bulk of the code lives under `app/src/main/java/li/crescio/penates/diana`, including feature packages like `recorder` for audio capture, `playback` for reviewing clips, `sync` for cloud coordination, and supporting layers such as `data`, `ui`, and `di` for persistence, presentation, and dependency injection respectively.
+- **docs** – Reference material, architectural decisions, deployment notes, and longer-form planning documents.
+- **scripts** – Utility scripts for development and automation tasks, such as build helpers or maintenance commands.
+- **samples** – Example inputs and artifacts useful for testing, demos, or exploratory work.
+
+## Key docs
+- `docs/ARCHITECTURE.md` – High-level system structure, core flows, and major components.
+- `docs/NOTES.md` – Working notes that capture design discussions, caveats, and ongoing investigations.
+- `docs/DEPLOYMENT.md` – Instructions for packaging and deploying the application.
+- `docs/thoughts/` – Planning documents and deeper design explorations.
+
 ## Testing
 
 - The full unit test suite can be slow. Run only the tests relevant to your changes.


### PR DESCRIPTION
## Summary
- add a "Getting oriented" section describing the main top-level directories and notable app packages
- list key documentation references so agents can quickly find deeper guidance
- keep the existing testing guidance in place below the new context

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d14983c0f88325ad6fbfc2cd0845bc