### PR TITLE
Add worklog document for active initiatives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - `docs/ARCHITECTURE.md` – High-level system structure, core flows, and major components.
 - `docs/NOTES.md` – Working notes that capture design discussions, caveats, and ongoing investigations.
 - `docs/DEPLOYMENT.md` – Instructions for packaging and deploying the application.
+- `docs/WORKLOG.md` – Current initiatives, status, and deep links into planning docs.
 - `docs/thoughts/` – Planning documents and deeper design explorations.
 
 ## Testing

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -34,4 +34,5 @@ The main source set lives under `app/src/main/java/li/crescio/penates/diana`. Ke
 - [ARCHITECTURE.md](ARCHITECTURE.md) – System overview, major flows, and component responsibilities.
 - [NOTES.md](NOTES.md) – Ongoing design discussions, open questions, and decision history.
 - [DEPLOYMENT.md](DEPLOYMENT.md) – Build, packaging, and release guidance.
+- [WORKLOG.md](WORKLOG.md) – Snapshot of active initiatives with links to deeper plans.
 - [`docs/thoughts/`](thoughts/) – Exploratory planning documents and deeper design dives.

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,0 +1,19 @@
+# Worklog
+
+This log captures active initiatives and recent pushes so contributors can orient quickly.
+
+## Active initiatives
+
+| Date       | Status      | Summary | Further detail |
+| ---------- | ----------- | ------- | -------------- |
+| 2025-09-22 | In progress | Thought-document refactor: migrate memo processing to produce markdown bodies and navigation outlines, update persistence, and expose the richer structure in the UI. | [Thought document refactor plan](thoughts/thought-document-plan.md) |
+
+## Template for new entries
+
+Add future updates with a quick bullet snapshot to keep momentum visible:
+
+- **Date**: YYYY-MM-DD
+- **Status**: e.g., In progress / Shipped / Blocked
+- **Summary**: One or two sentences describing scope and goals
+- **Key files & docs**: Links to implementation areas or planning notes
+


### PR DESCRIPTION
## Summary
- add docs/WORKLOG.md to capture active initiatives and link to detailed planning notes
- surface the worklog from docs/STRUCTURE.md and the root AGENTS guide for easier discovery

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d14c3a6e288325a58fcaca63df3d3c