### PR TITLE
Document tag catalog planning notes

### DIFF
--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -8,6 +8,7 @@ This log captures active initiatives and recent pushes so contributors can orien
 | ---------- | ----------- | ------- | -------------- |
 | 2025-09-24 | Shipped     | Delete-session dialog polished with vertically stacked Material buttons to preserve touch targets. | Verified via Compose previews on phone and tablet widths. |
 | 2025-09-22 | In progress | Thought-document refactor: migrate memo processing to produce markdown bodies and navigation outlines, update persistence, and expose the richer structure in the UI. | [Thought document refactor plan](thoughts/thought-document-plan.md) |
+| 2025-09-25 | In progress | Localized, user-managed tag catalog: scope curated tag list and orchestration for multilingual display. | [Tag catalog planning notes](thoughts/tag-catalog-plan.md) |
 
 ## Template for new entries
 

--- a/docs/thoughts/tag-catalog-plan.md
+++ b/docs/thoughts/tag-catalog-plan.md
@@ -1,0 +1,27 @@
+# Tag catalog planning notes
+
+## Background
+- Capture the need for a structured, multilingual tag system that can support search, filtering, and future analytics.
+
+## Goals
+- Define a sustainable approach for maintaining a curated catalog of tags managed directly by users or administrators.
+- Ensure localization support for Italian, French, and English audiences with graceful fallback behavior.
+- Outline integration touchpoints with existing note-taking and classification flows.
+
+## Requirements
+- The tag list must be user-curated with clear tooling for proposing, approving, and pruning entries to keep the catalog intentionally limited.
+- Tags must be localized for Italian, French, and English, with English strings serving as the fallback when a translation is missing.
+- Provide metadata hooks so other features can reference tag identifiers without duplicating localized labels.
+
+## Open questions
+- What constraints should we enforce on the maximum number of active tags per locale to balance flexibility against sprawl?
+- How will moderation rights be granted or revoked across different user roles?
+
+## Risks
+- Overly broad tag sets could dilute usefulness and introduce inconsistent translation quality.
+- Localization updates might lag behind new tag proposals, creating a fragmented user experience.
+
+## Next steps
+- Draft workflow diagrams for creating, editing, and deprecating tags across locales.
+- Identify instrumentation needed to monitor tag usage and inform future pruning.
+- Validate localization requirements with the content team and establish translation SLAs.


### PR DESCRIPTION
## Summary
- add an active-initiative entry for the localized tag catalog effort
- draft tag catalog planning notes covering background, goals, requirements, open questions, risks, and next steps with localization and curation requirements captured

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d240d4cca483259d87f749caf4b597