### PR TITLE
Add tag catalog repository with locale helpers and tests

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -80,6 +80,7 @@ import li.crescio.penates.diana.persistence.MemoRepository
 import li.crescio.penates.diana.session.Session
 import li.crescio.penates.diana.session.SessionRepository
 import li.crescio.penates.diana.session.SessionSettings
+import li.crescio.penates.diana.tags.TagCatalogRepository
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -301,6 +302,7 @@ class MainActivity : ComponentActivity() {
                             importableSessions = importableSessions,
                             repository = environment.noteRepository,
                             memoRepository = environment.memoRepository,
+                            tagCatalogRepository = environment.tagCatalogRepository,
                             onUpdateSession = { updatedSession ->
                                 val persisted = sessionRepository.update(updatedSession)
                                 environment = environment.copy(session = persisted)
@@ -369,6 +371,11 @@ class MainActivity : ComponentActivity() {
             session = session,
             noteRepository = NoteRepository(firestore, session.id, notesFile),
             memoRepository = MemoRepository(memoFile),
+            tagCatalogRepository = TagCatalogRepository(
+                sessionId = session.id,
+                sessionDir = sessionDir,
+                firestore = firestore,
+            ),
         )
     }
 
@@ -438,6 +445,7 @@ private data class SessionEnvironment(
     val session: Session,
     val noteRepository: NoteRepository,
     val memoRepository: MemoRepository,
+    val tagCatalogRepository: TagCatalogRepository,
 )
 
 private data class SessionInitialization(
@@ -452,6 +460,7 @@ fun DianaApp(
     importableSessions: List<Session>,
     repository: NoteRepository,
     memoRepository: MemoRepository,
+    tagCatalogRepository: TagCatalogRepository,
     onUpdateSession: (Session) -> Session,
     onSwitchSession: (Session) -> Unit,
     onAddSession: () -> Unit,

--- a/app/src/main/java/li/crescio/penates/diana/tags/TagCatalogRepository.kt
+++ b/app/src/main/java/li/crescio/penates/diana/tags/TagCatalogRepository.kt
@@ -1,0 +1,131 @@
+package li.crescio.penates.diana.tags
+
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+class TagCatalogRepository(
+    private val sessionId: String,
+    private val sessionDir: File,
+    private val firestore: FirebaseFirestore,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    private val catalogFile = File(sessionDir, "tags.json")
+    private val mutex = Mutex()
+
+    suspend fun loadCatalog(): TagCatalog = withContext(dispatcher) {
+        val local = mutex.withLock { readLocalLocked() }
+        if (local != null) {
+            return@withContext local
+        }
+        val remote = fetchRemote()
+        val catalog = remote.catalog ?: TagCatalog(emptyList())
+        if (remote.error == null && remote.catalog != null) {
+            mutex.withLock { writeLocalLocked(catalog) }
+        }
+        catalog
+    }
+
+    suspend fun saveCatalog(catalog: TagCatalog): TagCatalogSyncOutcome = withContext(dispatcher) {
+        mutex.withLock { writeLocalLocked(catalog) }
+        val error = try {
+            settingsDocument().set(catalog.toMap()).await()
+            null
+        } catch (e: Exception) {
+            e
+        }
+        TagCatalogSyncOutcome(catalog = catalog, error = error)
+    }
+
+    suspend fun syncFromRemote(): TagCatalogSyncOutcome = withContext(dispatcher) {
+        val remote = fetchRemote()
+        if (remote.error == null && remote.catalog != null) {
+            mutex.withLock { writeLocalLocked(remote.catalog) }
+        }
+        remote
+    }
+
+    private suspend fun fetchRemote(): TagCatalogSyncOutcome {
+        return try {
+            val snapshot = settingsDocument().get().await()
+            val data = snapshot.data
+            val catalog = if (data == null) {
+                TagCatalog(emptyList())
+            } else {
+                TagCatalog.fromMap(data)
+            }
+            TagCatalogSyncOutcome(catalog = catalog)
+        } catch (e: Exception) {
+            TagCatalogSyncOutcome(catalog = TagCatalog(emptyList()), error = e)
+        }
+    }
+
+    private fun readLocalLocked(): TagCatalog? {
+        if (!catalogFile.exists()) {
+            return null
+        }
+        return try {
+            val contents = catalogFile.readText()
+            if (contents.isBlank()) {
+                TagCatalog(emptyList())
+            } else {
+                TagCatalog.fromJson(JSONObject(contents))
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun writeLocalLocked(catalog: TagCatalog) {
+        val json = catalog.toJson().toString()
+        writeAtomically(json)
+    }
+
+    private fun writeAtomically(contents: String) {
+        val parent = catalogFile.parentFile ?: sessionDir
+        if (!parent.exists() && !parent.mkdirs()) {
+            throw IOException("Unable to create directory: ${parent.absolutePath}")
+        }
+        val tmp = File.createTempFile("tags", ".json.tmp", parent)
+        try {
+            tmp.writeText(contents, Charsets.UTF_8)
+            if (catalogFile.exists()) {
+                if (!tmp.renameTo(catalogFile)) {
+                    if (!catalogFile.delete() || !tmp.renameTo(catalogFile)) {
+                        tmp.copyTo(catalogFile, overwrite = true)
+                        tmp.delete()
+                    }
+                }
+            } else {
+                if (!tmp.renameTo(catalogFile)) {
+                    tmp.copyTo(catalogFile, overwrite = true)
+                    tmp.delete()
+                }
+            }
+        } finally {
+            if (tmp.exists()) {
+                tmp.delete()
+            }
+        }
+    }
+
+    private fun settingsDocument() = firestore
+        .collection("sessions")
+        .document(sessionId)
+        .collection("settings")
+        .document("tagCatalog")
+}
+
+data class TagCatalogSyncOutcome(
+    val catalog: TagCatalog?,
+    val error: Exception? = null,
+) {
+    val isSuccessful: Boolean get() = error == null
+}

--- a/app/src/main/java/li/crescio/penates/diana/tags/TagModels.kt
+++ b/app/src/main/java/li/crescio/penates/diana/tags/TagModels.kt
@@ -1,0 +1,249 @@
+package li.crescio.penates.diana.tags
+
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.Comparator
+import java.util.Locale
+
+private val LABEL_COMPARATOR = Comparator<LocalizedLabel> { first, second ->
+    val firstTag = first.normalizedLocaleTag
+    val secondTag = second.normalizedLocaleTag
+    when {
+        firstTag == secondTag -> 0
+        firstTag == null -> 1
+        secondTag == null -> -1
+        firstTag.length != secondTag.length -> secondTag.length.compareTo(firstTag.length)
+        else -> firstTag.compareTo(secondTag)
+    }
+}
+
+internal fun normalizeLocaleTag(tag: String): String {
+    return tag.replace('_', '-').lowercase(Locale.US)
+}
+
+data class LocalizedLabel(
+    val localeTag: String?,
+    val value: String,
+) {
+    init {
+        if (localeTag != null && localeTag.isBlank()) {
+            throw IllegalArgumentException("localeTag must be null or non-blank")
+        }
+    }
+
+    val normalizedLocaleTag: String? = localeTag?.let { normalizeLocaleTag(it) }
+
+    fun storageKey(): String {
+        return normalizedLocaleTag ?: DEFAULT_STORAGE_KEY
+    }
+
+    companion object {
+        const val DEFAULT_STORAGE_KEY = "default"
+
+        fun create(localeTag: String?, value: String): LocalizedLabel {
+            val normalized = localeTag?.takeUnless { it.isBlank() }?.let { normalizeLocaleTag(it) }
+            return LocalizedLabel(normalized, value)
+        }
+    }
+}
+
+data class TagDefinition(
+    val id: String,
+    val labels: List<LocalizedLabel>,
+    val color: String? = null,
+) {
+    fun labelForLocale(
+        locale: Locale,
+        fallbackLocales: List<Locale> = DEFAULT_FALLBACK_LOCALES,
+    ): String? {
+        if (labels.isEmpty()) {
+            return null
+        }
+        val byLocale = mutableMapOf<String, LocalizedLabel>()
+        var defaultLabel: LocalizedLabel? = null
+        labels.forEach { label ->
+            val normalized = label.normalizedLocaleTag
+            if (normalized == null) {
+                if (defaultLabel == null) {
+                    defaultLabel = label
+                }
+            } else if (!byLocale.containsKey(normalized)) {
+                byLocale[normalized] = label
+            }
+        }
+        val visited = mutableSetOf<String>()
+        LocaleFallback.candidates(locale).forEach { candidate ->
+            if (visited.add(candidate)) {
+                byLocale[candidate]?.let { return it.value }
+            }
+        }
+        fallbackLocales.forEach { fallback ->
+            LocaleFallback.candidates(fallback).forEach { candidate ->
+                if (visited.add(candidate)) {
+                    byLocale[candidate]?.let { return it.value }
+                }
+            }
+        }
+        defaultLabel?.let { return it.value }
+        return labels.first().value
+    }
+
+    fun toJson(): JSONObject {
+        val obj = JSONObject()
+        obj.put("id", id)
+        color?.takeUnless { it.isBlank() }?.let { obj.put("color", it) }
+        val labelsObject = JSONObject()
+        labels.sortedWith(LABEL_COMPARATOR).forEach { label ->
+            val key = label.storageKey()
+            if (!labelsObject.has(key)) {
+                labelsObject.put(key, label.value)
+            }
+        }
+        obj.put("labels", labelsObject)
+        return obj
+    }
+
+    fun toMap(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>("id" to id)
+        color?.takeUnless { it.isBlank() }?.let { map["color"] = it }
+        val labelsMap = linkedMapOf<String, String>()
+        labels.sortedWith(LABEL_COMPARATOR).forEach { label ->
+            val key = label.storageKey()
+            if (!labelsMap.containsKey(key)) {
+                labelsMap[key] = label.value
+            }
+        }
+        map["labels"] = labelsMap
+        return map
+    }
+
+    companion object {
+        val DEFAULT_FALLBACK_LOCALES: List<Locale> = listOf(Locale.ENGLISH)
+
+        fun fromJson(obj: JSONObject?): TagDefinition? {
+            if (obj == null) return null
+            val id = obj.optString("id", "").takeUnless { it.isBlank() } ?: return null
+            val color = obj.optString("color", "").takeUnless { it.isBlank() }
+            val labelsObj = obj.optJSONObject("labels") ?: JSONObject()
+            val labels = mutableListOf<LocalizedLabel>()
+            val keys = labelsObj.keys()
+            while (keys.hasNext()) {
+                val key = keys.next()
+                val rawValue = labelsObj.opt(key)
+                val raw = rawValue as? String ?: continue
+                val localeTag = if (key == LocalizedLabel.DEFAULT_STORAGE_KEY) null else key
+                labels += LocalizedLabel.create(localeTag, raw)
+            }
+            return TagDefinition(id, labels.sortedWith(LABEL_COMPARATOR), color)
+        }
+
+        fun fromMap(map: Map<*, *>?): TagDefinition? {
+            if (map == null) return null
+            val id = (map["id"] as? String)?.takeUnless { it.isBlank() } ?: return null
+            val color = (map["color"] as? String)?.takeUnless { it.isBlank() }
+            val labelsMap = map["labels"] as? Map<*, *>
+            val labels = mutableListOf<LocalizedLabel>()
+            labelsMap?.forEach { (key, value) ->
+                val keyString = key as? String ?: return@forEach
+                val labelValue = value as? String ?: return@forEach
+                val localeTag = if (keyString == LocalizedLabel.DEFAULT_STORAGE_KEY) null else keyString
+                labels += LocalizedLabel.create(localeTag, labelValue)
+            }
+            return TagDefinition(id, labels.sortedWith(LABEL_COMPARATOR), color)
+        }
+    }
+}
+
+data class TagCatalog(
+    val tags: List<TagDefinition>,
+) {
+    fun toJson(): JSONObject {
+        val obj = JSONObject()
+        val array = JSONArray()
+        tags.forEach { array.put(it.toJson()) }
+        obj.put("tags", array)
+        return obj
+    }
+
+    fun toMap(): Map<String, Any> {
+        return mapOf("tags" to tags.map { it.toMap() })
+    }
+
+    companion object {
+        fun fromJson(obj: JSONObject?): TagCatalog {
+            if (obj == null) return TagCatalog(emptyList())
+            val array = obj.optJSONArray("tags") ?: JSONArray()
+            val tags = mutableListOf<TagDefinition>()
+            for (i in 0 until array.length()) {
+                val element = array.optJSONObject(i) ?: continue
+                TagDefinition.fromJson(element)?.let { tags += it }
+            }
+            return TagCatalog(tags)
+        }
+
+        fun fromMap(map: Map<*, *>?): TagCatalog {
+            if (map == null) return TagCatalog(emptyList())
+            val rawTags = map["tags"] as? List<*>
+            val tags = mutableListOf<TagDefinition>()
+            rawTags?.forEach { entry ->
+                TagDefinition.fromMap(entry as? Map<*, *>)?.let { tags += it }
+            }
+            return TagCatalog(tags)
+        }
+    }
+}
+
+object LocaleFallback {
+    fun candidates(locale: Locale): Sequence<String> = sequence {
+        val normalizedBase = normalizeLocaleTag(locale.toLanguageTag())
+        if (normalizedBase.isNotBlank()) {
+            yield(normalizedBase)
+        }
+        val builder = Locale.Builder()
+        val language = locale.language
+        if (language.isNotEmpty()) {
+            builder.setLanguage(language)
+        }
+        val script = locale.script
+        val region = locale.country
+        val variant = locale.variant
+        if (script.isNotEmpty()) {
+            builder.setScript(script)
+        }
+        if (region.isNotEmpty()) {
+            builder.setRegion(region)
+        }
+        if (variant.isNotEmpty()) {
+            builder.setVariant(variant)
+            val withoutVariant = builder.build().toLanguageTag()
+            val normalized = normalizeLocaleTag(withoutVariant)
+            if (normalized.isNotBlank() && normalized != normalizedBase) {
+                yield(normalized)
+            }
+            builder.setVariant("")
+        }
+        if (region.isNotEmpty()) {
+            val withoutRegion = builder.build().toLanguageTag()
+            val normalized = normalizeLocaleTag(withoutRegion)
+            if (normalized.isNotBlank() && normalized != normalizedBase) {
+                yield(normalized)
+            }
+            builder.setRegion("")
+        }
+        if (script.isNotEmpty()) {
+            val withoutScript = builder.build().toLanguageTag()
+            val normalized = normalizeLocaleTag(withoutScript)
+            if (normalized.isNotBlank() && normalized != normalizedBase) {
+                yield(normalized)
+            }
+            builder.setScript("")
+        }
+        if (language.isNotEmpty()) {
+            val normalizedLanguage = normalizeLocaleTag(language)
+            if (normalizedLanguage.isNotBlank() && normalizedLanguage != normalizedBase) {
+                yield(normalizedLanguage)
+            }
+        }
+        yield(LocalizedLabel.DEFAULT_STORAGE_KEY)
+    }
+}

--- a/app/src/test/java/li/crescio/penates/diana/persistence/NoteRepositoryTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/persistence/NoteRepositoryTest.kt
@@ -285,7 +285,7 @@ class NoteRepositoryTest {
         every { firestore.collection("sessions") } returns sessionsCollection
         every { sessionsCollection.document(SESSION_ID) } returns sessionDocument
         every { sessionDocument.collection("notes") } returns collection
-        every { collection.whereEqualTo(any(), any()) } returns collection
+        every { collection.whereEqualTo(any<String>(), any()) } returns collection
         every { collection.get() } returns Tasks.forResult(querySnapshot)
         every { querySnapshot.documents } returns emptyList()
         every { collection.document(any()) } returns docRef

--- a/app/src/test/java/li/crescio/penates/diana/tags/TagCatalogRepositoryTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/tags/TagCatalogRepositoryTest.kt
@@ -1,0 +1,128 @@
+package li.crescio.penates.diana.tags
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.FirebaseFirestore
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.util.Locale
+import kotlin.io.path.createTempDirectory
+
+class TagCatalogRepositoryTest {
+
+    @Test
+    fun serialization_roundTrip() {
+        val catalog = TagCatalog(
+            tags = listOf(
+                TagDefinition(
+                    id = "home",
+                    labels = listOf(
+                        LocalizedLabel.create("en-US", "Home"),
+                        LocalizedLabel.create("en", "Home (general)"),
+                        LocalizedLabel.create(null, "Casa"),
+                    ),
+                    color = "#ff0000",
+                ),
+                TagDefinition(
+                    id = "work",
+                    labels = listOf(
+                        LocalizedLabel.create("fr", "Travail"),
+                        LocalizedLabel.create(null, "Work"),
+                    ),
+                ),
+            ),
+        )
+
+        val json = catalog.toJson().toString()
+        val parsedFromJson = TagCatalog.fromJson(JSONObject(json))
+        assertEquals(catalog, parsedFromJson)
+
+        val map = catalog.toMap()
+        val parsedFromMap = TagCatalog.fromMap(map)
+        assertEquals(catalog, parsedFromMap)
+    }
+
+    @Test
+    fun labelForLocale_appliesFallbackOrdering() {
+        val definition = TagDefinition(
+            id = "travel",
+            labels = listOf(
+                LocalizedLabel.create("en-GB", "Holiday"),
+                LocalizedLabel.create("en", "Vacation"),
+                LocalizedLabel.create("fr", "Vacances"),
+                LocalizedLabel.create(null, "Trip"),
+            ),
+        )
+
+        assertEquals("Holiday", definition.labelForLocale(Locale.UK))
+        assertEquals("Vacation", definition.labelForLocale(Locale.US))
+        assertEquals("Vacances", definition.labelForLocale(Locale.CANADA_FRENCH))
+        assertEquals("Vacation", definition.labelForLocale(Locale("es", "ES")))
+
+        val fallbackToDefault = TagDefinition(
+            id = "task",
+            labels = listOf(
+                LocalizedLabel.create("it", "Compito"),
+                LocalizedLabel.create(null, "Task"),
+            ),
+        )
+
+        assertEquals("Task", fallbackToDefault.labelForLocale(Locale("es", "MX")))
+        assertNull(TagDefinition("empty", emptyList()).labelForLocale(Locale.US))
+    }
+
+    @Test
+    fun saveCatalog_remoteFailureReturnsErrorAndPersistsLocal() = runBlocking {
+        System.setProperty("net.bytebuddy.experimental", "true")
+        val sessionDir = createTempDirectory().toFile()
+        val firestore = mockk<FirebaseFirestore>()
+        val sessionsCollection = mockk<CollectionReference>()
+        val sessionDocument = mockk<DocumentReference>()
+        val settingsCollection = mockk<CollectionReference>()
+        val tagDocument = mockk<DocumentReference>()
+
+        every { firestore.collection("sessions") } returns sessionsCollection
+        every { sessionsCollection.document("session") } returns sessionDocument
+        every { sessionDocument.collection("settings") } returns settingsCollection
+        every { settingsCollection.document("tagCatalog") } returns tagDocument
+        every { tagDocument.set(any()) } returns Tasks.forException(RuntimeException("boom"))
+
+        val repository = TagCatalogRepository(
+            sessionId = "session",
+            sessionDir = sessionDir,
+            firestore = firestore,
+        )
+        val catalog = TagCatalog(
+            tags = listOf(
+                TagDefinition(
+                    id = "home",
+                    labels = listOf(LocalizedLabel.create(null, "Home")),
+                ),
+            ),
+        )
+
+        val result = repository.saveCatalog(catalog)
+
+        assertFalse(result.isSuccessful)
+        assertNotNull(result.error)
+        assertEquals(catalog, result.catalog)
+
+        val file = File(sessionDir, "tags.json")
+        assertTrue(file.exists())
+        val parsed = TagCatalog.fromJson(JSONObject(file.readText()))
+        assertEquals(catalog, parsed)
+
+        verify(exactly = 1) { tagDocument.set(any()) }
+    }
+}

--- a/app/src/test/java/li/crescio/penates/diana/ui/NotesListScreenTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/ui/NotesListScreenTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assert
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -40,6 +39,7 @@ class NotesListScreenTest {
                 todoItems = listOf(item),
                 appointments = emptyList(),
                 notes = emptyList(),
+                thoughtDocument = null,
                 logs = emptyList(),
                 showTodos = true,
                 showAppointments = false,
@@ -106,7 +106,6 @@ class NotesListScreenTest {
         }
 
         val markdownNode = composeTestRule.onNodeWithTag("thought-markdown")
-        markdownNode.assertExists()
         markdownNode.assert(
             SemanticsMatcher.expectValue(
                 SemanticsProperties.Text,


### PR DESCRIPTION
## Summary
- add tag catalog data models with deterministic locale fallback behaviour and serialization helpers
- implement a session-scoped TagCatalogRepository that persists tags.json locally and synchronizes with Firestore
- expose the repository from MainActivity session environments and add unit coverage for serialization, fallback, and sync error handling (including minor test harness fixes)

## Testing
- ./gradlew --no-daemon --console=plain :app:testDebugUnitTest --tests "li.crescio.penates.diana.tags.TagCatalogRepositoryTest"

------
https://chatgpt.com/codex/tasks/task_e_68d246803f6c832595ddef411d9bf41a