### PR TITLE
Integrate tag catalog guardrails for MemoProcessor

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -539,7 +539,8 @@ fun DianaApp(
             BuildConfig.OPENROUTER_API_KEY,
             logger,
             Locale.getDefault(),
-            initialModel = sanitizedModel
+            initialModel = sanitizedModel,
+            tagCatalogRepository = tagCatalogRepository,
         )
     }
     LaunchedEffect(session) {

--- a/app/src/main/resources/llm/prompts/en/user.txt
+++ b/app/src/main/resources/llm/prompts/en/user.txt
@@ -34,8 +34,8 @@ Rules:
    - If updating an existing item that was "done", keep "done" unless new memo clearly reopens the task.
 
 6) Tags
-   - Provide 1–3 short tags, all lowercase, in the memo’s language (e.g., italiano: "salute", "scadenza", "monitoraggio").
-   - Prefer domain tags implied by the memo; avoid generic noise.
+   - Choose 1–3 tag IDs from the approved catalog below. Do NOT invent new IDs.
+   - Return the IDs exactly as listed (case-sensitive). If no ID fits perfectly, pick the closest available option.
 
 7) Safety
    - No duplication.
@@ -47,6 +47,9 @@ Context:
 {prior}
 
 - Today’s date (YYYY-MM-DD): {today}
+
+- Approved tag catalog (ID → label):
+{tag_catalog}
 
 - New memo (free text to analyze):
 {memo}

--- a/app/src/main/resources/llm/prompts/fr/user.txt
+++ b/app/src/main/resources/llm/prompts/fr/user.txt
@@ -34,20 +34,23 @@ Règles :
    - Utilisez "cancelled" si la tâche ne sera pas faite.
    - Si vous mettez à jour un élément déjà "done", gardez "done" sauf si le mémo rouvre clairement la tâche.
 
-6) Tags  
-   - Fournissez 1–3 tags courts, tous en minuscules, dans la langue du mémo (ex. français : « santé », « échéance », « suivi »).  
-   - Préférez les tags liés au domaine suggéré par le mémo ; évitez les termes trop génériques.  
+6) Tags
+   - Choisissez 1 à 3 identifiants de tag dans le catalogue approuvé ci-dessous. N’inventez PAS de nouveaux identifiants.
+   - Retournez les identifiants exactement tels qu’ils apparaissent (sensible à la casse). Si aucun ID ne correspond parfaitement, choisissez l’option disponible la plus proche.
 
 7) Sécurité  
    - Pas de duplication.  
    - Soyez concis : chaque "text" est une seule phrase actionnable.  
    - N’incluez jamais de copies brutes du prior ou du mémo en dehors du "text" nettoyé.  
 
-Contexte :  
-- Éléments précédents (JSON structuré) :  
-{prior}  
+Contexte :
+- Éléments précédents (JSON structuré) :
+{prior}
 
-- Date d’aujourd’hui (AAAA-MM-JJ) : {today}  
+- Date d’aujourd’hui (AAAA-MM-JJ) : {today}
 
-- Nouveau mémo (texte libre à analyser) :  
-{memo}  
+- Catalogue de tags approuvé (ID → libellé) :
+{tag_catalog}
+
+- Nouveau mémo (texte libre à analyser) :
+{memo}

--- a/app/src/main/resources/llm/prompts/it/user.txt
+++ b/app/src/main/resources/llm/prompts/it/user.txt
@@ -33,20 +33,23 @@ Regole:
    - Usa "cancelled" se l’attività non verrà svolta.
    - Se aggiorni un elemento già "done", mantieni "done" a meno che il nuovo memo non riapra chiaramente l’attività.
 
-6) Tag  
-   - Fornisci 1–3 tag brevi, tutti in minuscolo, nella lingua del memo (es. italiano: « salute », « scadenza », « monitoraggio »).  
-   - Preferisci tag legati al dominio suggerito dal memo; evita termini troppo generici.  
+6) Tag
+   - Scegli 1–3 ID di tag dal catalogo approvato qui sotto. NON inventare nuovi ID.
+   - Restituisci gli ID esattamente come elencati (rispetta maiuscole/minuscole). Se nessun ID è perfetto, scegli l’opzione disponibile più vicina.
 
 7) Sicurezza  
    - Nessuna duplicazione.  
    - Sii conciso: ogni "text" è una sola frase eseguibile.  
    - Non includere mai copie grezze del prior o del memo al di fuori del "text" pulito.  
 
-Contesto:  
-- Elementi precedenti (JSON strutturato):  
-{prior}  
+Contesto:
+- Elementi precedenti (JSON strutturato):
+{prior}
 
-- Data di oggi (AAAA-MM-GG): {today}  
+- Data di oggi (AAAA-MM-GG): {today}
 
-- Nuovo memo (testo libero da analizzare):  
-{memo}  
+- Catalogo di tag approvato (ID → etichetta):
+{tag_catalog}
+
+- Nuovo memo (testo libero da analizzare):
+{memo}

--- a/app/src/main/resources/llm/schema/thought.json
+++ b/app/src/main/resources/llm/schema/thought.json
@@ -16,7 +16,7 @@
             "text": { "type": "string" },
             "tags": {
               "type": "array",
-              "items": { "type": "string" }
+              "items": { "type": "string", "enum": [] }
             }
           },
           "required": ["text", "tags"]

--- a/app/src/main/resources/llm/schema/todo.json
+++ b/app/src/main/resources/llm/schema/todo.json
@@ -30,7 +30,7 @@
               "type": "array",
               "minItems": 1,
               "maxItems": 3,
-              "items": { "type": "string", "pattern": "^[a-zàèéìòóùç ]+$" }
+              "items": { "type": "string", "enum": [] }
             },
             "due_date": { "type": "string", "format": "date" },
             "event_date": { "type": "string", "format": "date" }


### PR DESCRIPTION
## Summary
- update MemoProcessor to hydrate tag catalog data, sanitize memo tags, and inject approved IDs into prompts and schema requests
- rewrite localized prompt instructions and JSON schemas to require choosing tag IDs from the catalog
- expand MemoProcessor unit coverage to validate catalog enforcement, logging, and prompt/schema content

## Testing
- ./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.MemoProcessorTest" *(fails: Android Build Tools 34.0.0 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d269aa8c308325af8e2406da60efa1