### PR TITLE
Add tag ID persistence and legacy migration

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
+++ b/app/src/main/java/li/crescio/penates/diana/notes/Models.kt
@@ -1,5 +1,9 @@
 package li.crescio.penates.diana.notes
 
+import li.crescio.penates.diana.tags.TagCatalog
+import java.util.LinkedHashSet
+import java.util.Locale
+
 data class RawRecording(val filePath: String)
 
 data class Transcript(val text: String)
@@ -12,23 +16,63 @@ data class Memo(
 )
 
 sealed class StructuredNote(open val createdAt: Long) {
+    interface Tagged {
+        val tagIds: List<String>
+        val tagLabels: List<String>
+
+        fun unresolvedTagLabels(): List<String> = tagLabels
+
+        fun displayTags(): List<String> =
+            if (tagLabels.isNotEmpty()) tagLabels else tagIds
+
+        val tags: List<String>
+            get() = displayTags()
+
+        fun resolvedTagLabels(
+            catalog: TagCatalog?,
+            locale: Locale = Locale.getDefault(),
+        ): List<String> {
+            val resolved = LinkedHashSet<String>()
+            if (catalog != null) {
+                val byId = catalog.tags.associateBy { it.id }
+                tagIds.forEach { id ->
+                    val definition = byId[id]
+                    val label = definition?.labelForLocale(locale)
+                        ?: definition?.labels?.firstOrNull()?.value
+                    resolved.add(label?.takeIf { it.isNotBlank() } ?: id)
+                }
+            } else {
+                resolved.addAll(tagIds)
+            }
+            tagLabels.forEach { label ->
+                val trimmed = label.trim()
+                if (trimmed.isNotEmpty()) {
+                    resolved.add(trimmed)
+                }
+            }
+            return resolved.toList()
+        }
+    }
+
     data class ToDo(
         val text: String,
         val status: String = "",
-        val tags: List<String> = emptyList(),
+        override val tagIds: List<String> = emptyList(),
+        override val tagLabels: List<String> = emptyList(),
         val dueDate: String = "",
         val eventDate: String = "",
         override val createdAt: Long = System.currentTimeMillis(),
         val id: String = ""
-    ) : StructuredNote(createdAt)
+    ) : StructuredNote(createdAt), Tagged
 
     data class Memo(
         val text: String,
-        val tags: List<String> = emptyList(),
+        override val tagIds: List<String> = emptyList(),
+        override val tagLabels: List<String> = emptyList(),
         val sectionAnchor: String? = null,
         val sectionTitle: String? = null,
         override val createdAt: Long = System.currentTimeMillis(),
-    ) : StructuredNote(createdAt)
+    ) : StructuredNote(createdAt), Tagged
 
     data class Event(
         val text: String,
@@ -39,9 +83,10 @@ sealed class StructuredNote(open val createdAt: Long) {
 
     data class Free(
         val text: String,
-        val tags: List<String> = emptyList(),
+        override val tagIds: List<String> = emptyList(),
+        override val tagLabels: List<String> = emptyList(),
         override val createdAt: Long = System.currentTimeMillis()
-    ) : StructuredNote(createdAt)
+    ) : StructuredNote(createdAt), Tagged
 }
 
 data class NoteCollection(val notes: List<StructuredNote>)

--- a/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt
@@ -377,8 +377,8 @@ class MemoProcessorTest {
                 processAppointments = false,
             )
 
-            assertEquals(listOf("tag"), summary.todoItems.first().tags)
-            assertEquals(listOf("tag"), summary.thoughtItems.first().tags)
+            assertEquals(listOf("tag"), summary.todoItems.first().tagIds)
+            assertEquals(listOf("tag"), summary.thoughtItems.first().tagIds)
             verify(atLeast = 2) {
                 Log.w("MemoProcessor", match { it.contains("Dropping disallowed tags") })
             }
@@ -443,7 +443,7 @@ class MemoProcessorTest {
         assertEquals("main-topic", root.anchor)
         assertEquals(1, root.children.size)
         assertEquals("custom", root.children.first().anchor)
-        assertEquals(listOf("reflection"), summary.thoughtItems.first().tags)
+        assertEquals(listOf("reflection"), summary.thoughtItems.first().tagIds)
 
         server.shutdown()
     }

--- a/app/src/test/java/li/crescio/penates/diana/ui/ThoughtsSectionUtilsTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/ui/ThoughtsSectionUtilsTest.kt
@@ -36,18 +36,18 @@ class ThoughtsSectionUtilsTest {
         val notes = listOf(
             StructuredNote.Memo(
                 text = "Anchor note",
-                tags = listOf("anchor"),
+                tagIds = listOf("anchor"),
                 sectionAnchor = "intro",
                 sectionTitle = "Intro",
             ),
             StructuredNote.Memo(
                 text = "Title note",
-                tags = listOf("title"),
+                tagIds = listOf("title"),
                 sectionTitle = "Intro",
             ),
             StructuredNote.Free(
                 text = "Loose",
-                tags = listOf("free"),
+                tagIds = listOf("free"),
             ),
         )
 


### PR DESCRIPTION
## Summary
* augment structured notes and LLM DTOs to carry tag IDs with helper label accessors
* persist tag identifiers locally and in Firestore while migrating legacy tag strings via the catalog
* wire tag catalog usage into the session environment and update tests for new migration flows

## Testing
* `./gradlew --console=plain :app:testDebugUnitTest` *(fails: Android SDK Platform 34 build properties missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d27ab3b40483258621e1713e910feb