### PR TITLE
Finish memo processor tag normalization

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt
@@ -288,7 +288,6 @@ class MemoProcessor(
         val itemsArr = JSONArray()
         for (item in sanitizedItems) {
             val itemObj = JSONObject()
-            itemObj.put("id", item.id)
             itemObj.put("text", item.text)
             itemObj.put("status", item.status)
             val tagsArr = JSONArray()

--- a/app/src/test/java/li/crescio/penates/diana/persistence/NoteRepositoryTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/persistence/NoteRepositoryTest.kt
@@ -525,7 +525,7 @@ class NoteRepositoryTest {
         val toJson = NoteRepository::class.java.getDeclaredMethod("toJson", StructuredNote::class.java)
             .apply { isAccessible = true }
         val tagContextClass = Class.forName(
-            "li.crescio.penates.diana.persistence.NoteRepository\\$TagMappingContext"
+            "li.crescio.penates.diana.persistence.NoteRepository\$TagMappingContext"
         )
         val companionField = tagContextClass.getDeclaredField("Companion").apply { isAccessible = true }
         val companion = companionField.get(null)

--- a/app/src/test/java/li/crescio/penates/diana/ui/NotesListScreenTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/ui/NotesListScreenTest.kt
@@ -32,7 +32,7 @@ class NotesListScreenTest {
         val item = TodoItem(
             text = "Finished task",
             status = "done",
-            tags = listOf("tag"),
+            tagIds = listOf("tag"),
         )
         composeTestRule.setContent {
             NotesListScreen(

--- a/app/src/test/java/li/crescio/penates/diana/ui/ThoughtsSectionUtilsTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/ui/ThoughtsSectionUtilsTest.kt
@@ -2,8 +2,12 @@ package li.crescio.penates.diana.ui
 
 import li.crescio.penates.diana.notes.StructuredNote
 import li.crescio.penates.diana.notes.ThoughtOutlineSection
+import li.crescio.penates.diana.tags.LocalizedLabel
+import li.crescio.penates.diana.tags.TagCatalog
+import li.crescio.penates.diana.tags.TagDefinition
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.util.Locale
 
 class ThoughtsSectionUtilsTest {
     @Test
@@ -54,11 +58,39 @@ class ThoughtsSectionUtilsTest {
         val index = buildSectionTagIndex(notes)
 
         val anchorTags = index.tagsFor(ThoughtOutlineSection("Intro", 1, "intro"))
-        assertEquals(setOf("anchor"), anchorTags)
+        assertEquals(setOf("anchor"), anchorTags.map { it.id }.toSet())
 
         val fallbackTags = index.tagsFor(ThoughtOutlineSection("Intro", 1, "missing"))
-        assertEquals(setOf("title"), fallbackTags)
+        assertEquals(setOf("anchor", "title"), fallbackTags.map { it.id }.toSet())
 
-        assertEquals(setOf("anchor", "title", "free"), index.allTags)
+        assertEquals(setOf("anchor", "title", "free"), index.allTags.map { it.id }.toSet())
+    }
+
+    @Test
+    fun buildSectionTagIndex_resolvesCatalogLabelsForLocale() {
+        val notes = listOf(
+            StructuredNote.Memo(
+                text = "Localized",
+                tagIds = listOf("anchor"),
+                sectionAnchor = "intro",
+            )
+        )
+        val catalog = TagCatalog(
+            listOf(
+                TagDefinition(
+                    id = "anchor",
+                    labels = listOf(
+                        LocalizedLabel.create("en", "Anchor"),
+                        LocalizedLabel.create("fr", "Ancre")
+                    )
+                )
+            )
+        )
+
+        val index = buildSectionTagIndex(notes, catalog, Locale.FRENCH)
+
+        val resolved = index.tagsFor(ThoughtOutlineSection("Intro", 1, "intro")).single()
+        assertEquals("anchor", resolved.id)
+        assertEquals("Ancre", resolved.label)
     }
 }

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -14,7 +14,8 @@
 The main source set lives under `app/src/main/java/li/crescio/penates/diana`. Key packages include:
 
 - `llm/` – Integrations for language-model processing, prompt management, resource loading, and structured memo summarization.
-- `notes/` – Domain models describing recordings, transcripts, memos, and other note abstractions shared across features.
+- `notes/` – Domain models describing recordings, transcripts, memos, and other note abstractions shared across features. Structured notes now persist tag identifiers while helper methods resolve localized labels for display.
+- `tags/` – Tag catalog definitions, localization helpers, and editor state used to synchronize identifier/label mappings across processing and UI.
 - `persistence/` – Repository classes that coordinate reads and writes of memos, notes, and session metadata.
 - `player/` – Audio playback interfaces and the Android-specific implementation.
 - `recorder/` – Audio capture interfaces and Android recorder implementation details.


### PR DESCRIPTION
## Summary
- resolve structured note tag chips and filters through TagCatalog helpers so UI searches localized labels while persisting tag IDs
- keep the latest TagCatalog in MainActivity and pass it into MemoProcessor/NotesListScreen so LLM requests and chips display localized text with English fallbacks
- tighten MemoProcessor tests to parse the prompt payload, ensure tag enums are localized IDs, and normalize todo prior JSON

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.MemoProcessorTest.process_handlesSpecialCharacters"`
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.MemoProcessorTest"`
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.ui.ThoughtsSectionUtilsTest"`
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.ui.NotesListScreenTest"` *(fails: Robolectric Maven artifact fetch hit SocketException)*

------
https://chatgpt.com/codex/tasks/task_e_68d298016c70832587c0aa4fe4567250