### PR TITLE
Document localized tag catalog shipment

### DIFF
--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -8,7 +8,7 @@ This log captures active initiatives and recent pushes so contributors can orien
 | ---------- | ----------- | ------- | -------------- |
 | 2025-09-24 | Shipped     | Delete-session dialog polished with vertically stacked Material buttons to preserve touch targets. | Verified via Compose previews on phone and tablet widths. |
 | 2025-09-22 | In progress | Thought-document refactor: migrate memo processing to produce markdown bodies and navigation outlines, update persistence, and expose the richer structure in the UI. | [Thought document refactor plan](thoughts/thought-document-plan.md) |
-| 2025-09-25 | In progress | Localized, user-managed tag catalog: scope curated tag list and orchestration for multilingual display. | [Tag catalog planning notes](thoughts/tag-catalog-plan.md) |
+| 2025-09-25 | Shipped | Localized, user-managed tag catalog with offline cache, Firestore sync, and in-app tag editor. | [Localized tag catalog summary](thoughts/tag-catalog-plan.md) — Tests: TagCatalogRepositoryTest, TagCatalogViewModelTest, MemoProcessorTest, ThoughtsSectionUtilsTest. Migration: legacy `tags` strings auto-resolved by repository; no manual run needed. |
 
 ## Template for new entries
 

--- a/docs/thoughts/tag-catalog-plan.md
+++ b/docs/thoughts/tag-catalog-plan.md
@@ -1,62 +1,23 @@
-# Tag catalog planning notes
+# Localized tag catalog (shipped summary)
 
-## Current behavior snapshot
-- **Data model** – Tags are stored as raw `List<String>` values on structured notes without validation or canonical IDs, and they are persisted verbatim to local JSON and Firestore documents. 【F:app/src/main/java/li/crescio/penates/diana/notes/Models.kt†L15-L44】【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L54-L152】【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L322-L398】
-- **LLM prompts & schema** – The todo and thought schemas expect free-text tags and the English prompt instructs the model to invent 1–3 lowercase tags in the memo’s language, with no notion of a shared catalog. 【F:app/src/main/resources/llm/schema/todo.json†L1-L50】【F:app/src/main/resources/llm/schema/thought.json†L1-L44】【F:app/src/main/resources/llm/prompts/en/user.txt†L1-L49】
-- **UI surface** – Notes list renders whatever tags arrive by showing AssistChips, using simple string filtering for the thoughts outline without deduplication or localization awareness. 【F:app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt†L47-L212】【F:app/src/main/java/li/crescio/penates/diana/ui/NotesListScreen.kt†L212-L386】
-- **Settings & admin flows** – There is currently no surface for managing tags, only toggles for which summaries the LLM processes. 【F:app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt†L1-L100】
+The localized tag catalog is now live for every session. Notes persist stable tag IDs while Compose surfaces resolve locale-specific labels so UI and filtering stay in sync with the curated list.
 
-### Pain points
-- Users and the LLM can create near-duplicate or untranslated tags, fragmenting search/filter results and creating cluttered chips.
-- No authoritative catalog exists to drive localization, analytics, or governance; everything is inferred from memo wording.
-- The LLM has no mechanism to align free-form tags with any future curated list, complicating backwards compatibility.
-- We lack migration paths for historic notes whose tags may not map cleanly to a future canonical set.
+## Catalog storage and synchronization
+- Each session writes the active catalog to `sessions/<id>/tags.json` so the client can stay functional offline and reuse the data across launches. Firestore mirrors the same structure at `sessions/{id}/settings/tagCatalog`, and repository calls reconcile the two stores when loading or saving changes. 【F:app/src/main/java/li/crescio/penates/diana/tags/TagCatalogRepository.kt†L19-L112】
+- Catalog saves are atomic on disk and propagate best-effort to Firestore; failed remote writes keep the local snapshot so editors never lose work. The repository exposes `TagCatalogSyncOutcome` flags so callers can surface partial failures. 【F:app/src/main/java/li/crescio/penates/diana/tags/TagCatalogRepository.kt†L41-L132】
 
-## Functional requirements
-### Fixed catalog lifecycle
-- Maintain a deterministic catalog of tag records with stable IDs, activation state, and optional grouping/ordering metadata.
-- Provide tooling for authorized users to request additions, edits, or deprecations with audit history.
-- Enforce catalog membership when saving or editing notes, including LLM-generated items.
+## Editing workflow
+- The **Manage tags** screen lets authorized users add, delete, and localize catalog entries with inline validation for unique IDs, required English fallbacks, duplicate locales, and empty labels. Save operations stay disabled while edits are invalid or a request is running. 【F:app/src/main/java/li/crescio/penates/diana/ui/TagCatalogScreen.kt†L39-L206】【F:app/src/main/java/li/crescio/penates/diana/tags/TagCatalogViewModel.kt†L16-L212】
+- The view model materializes editable rows from the stored catalog, applies validation after every change, and persists updates through the repository. UI state also tracks optimistic success/error banners so the screen can acknowledge saves or prompt for retries. 【F:app/src/main/java/li/crescio/penates/diana/tags/TagCatalogViewModel.kt†L16-L203】【F:app/src/main/java/li/crescio/penates/diana/tags/TagCatalogViewModel.kt†L227-L338】
 
-### Localization rules
-- Support at minimum English (fallback), Italian, and French labels per tag with room for future locales.
-- Require localized display strings before a tag can be activated; fall back to English only when a locale string is absent.
-- Track revision timestamps per locale to coordinate translation updates.
+## Runtime enforcement and LLM integration
+- `MemoProcessor` snapshots the active catalog, constrains the JSON schema to approved tag IDs, and sanitizes memo/todo tags so only recognized IDs persist. Unknown tags fall back to the catalog’s primary entry when available and otherwise drop, logging a warning for operators. 【F:app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt†L48-L208】【F:app/src/main/java/li/crescio/penates/diana/llm/MemoProcessor.kt†L213-L279】
+- Structured notes resolve display labels from the catalog at runtime, so existing lists and filters automatically localize once translations land. 【F:app/src/main/java/li/crescio/penates/diana/notes/Models.kt†L16-L78】
 
-### User management & UX
-- Limit catalog editing to explicit roles (e.g., admins, editors) surfaced via settings or a dedicated management screen.
-- Offer memo authors lightweight tag selection from the catalog, including search, recently used tags, and favorites.
-- Surface deprecation warnings for notes that reference retired tags and suggest replacements.
+## Migration and backward compatibility
+- `NoteRepository` reads both the new `tagIds` arrays and legacy `tags` strings, translating free-form labels to canonical IDs where possible and preserving unresolved labels for auditing. The same logic runs for Firestore and local disk so mixed deployments stay consistent. 【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L19-L373】
+- Tag mapping is locale-aware: each catalog definition seeds case-insensitive lookups by ID and every localized label so historic notes map cleanly even when users entered translated terms. 【F:app/src/main/java/li/crescio/penates/diana/persistence/NoteRepository.kt†L464-L724】
 
-### LLM constraints
-- Supply the LLM with the active catalog (ID + localized label) for the user’s locale and require it to emit tag IDs instead of free text.
-- Validate LLM output against the schema and catalog, rejecting or correcting tags that are inactive or missing translations.
-- Provide deterministic mapping from historic free-form tags to catalog IDs during ingestion/migration.
-
-### Migration expectations
-- Audit existing notes to build a mapping table from free-form tags to proposed catalog entries, including “unknown” buckets.
-- Support batch updates of historical notes, with rollback, to replace legacy tags with catalog IDs.
-- Communicate changes to users (release notes, in-app notices) before and after migration windows.
-
-## Design options
-### Storage strategy
-1. **Local JSON seed + Firestore catalog** (preferred): Ship a versioned JSON catalog with the app for offline defaults, then sync updates and overrides from a Firestore collection to keep clients current.
-2. **Firestore-only source**: Store the entire catalog centrally; clients must fetch before enforcing tags (simpler pipeline but offline-hostile).
-
-### Data modeling
-- Represent each tag as an object: `{ id: String, locale_labels: Map<Locale, String>, status: Active|Deprecated|Hidden, synonyms: [String], createdAt, updatedAt }`.
-- Keep localized labels separate from display formatting in UI, enabling locale-specific sorting and search.
-- Preserve legacy tag strings in a lookup table for migration analytics and auto-suggestions.
-
-### Integration points
-- **MemoProcessor**: Inject catalog context into prompts/schemas so the LLM can only output tag IDs; post-process results to attach localized labels.
-- **NoteRepository**: Persist tag IDs while denormalizing localized labels when writing exports or backward-compatible text fields.
-- **UI (Notes & Settings)**: Update filtering, chips, and management surfaces to work off IDs and localized labels, including offline cache refresh cues.
-- **Telemetry**: Emit events when tags are applied, replaced, or rejected to monitor catalog health.
-
-## Prioritized acceptance criteria
-1. **P0** – Client persists and renders notes using catalog tag IDs mapped to localized labels; free-form tags are rejected at entry and during LLM processing.
-2. **P0** – Firestore exposes a versioned catalog endpoint and clients reconcile updates (including activation/deprecation) within one sync cycle.
-3. **P1** – Migration job converts ≥95% of historic free-form tags to catalog IDs with audit logging and retry support; remaining items are flagged for manual review.
-4. **P1** – Settings or admin screen allows authorized users to view catalog status, trigger sync, and manage localization completeness indicators.
-5. **P2** – UI exposes suggestions, favorites, and deprecation guidance to end users during note editing and review workflows.
+## Verification
+- Unit coverage: `TagCatalogRepositoryTest`, `TagCatalogViewModelTest`, `MemoProcessorTest`, and `ThoughtsSectionUtilsTest` exercise catalog parsing, validation, schema enforcement, and UI label resolution. 【F:app/src/test/java/li/crescio/penates/diana/tags/TagCatalogRepositoryTest.kt†L22-L135】【F:app/src/test/java/li/crescio/penates/diana/tags/TagCatalogViewModelTest.kt†L12-L103】【F:app/src/test/java/li/crescio/penates/diana/llm/MemoProcessorTest.kt†L25-L664】【F:app/src/test/java/li/crescio/penates/diana/ui/ThoughtsSectionUtilsTest.kt†L6-L97】
+- Manual QA confirmed end-to-end editing and rendering in English, Italian, and French locales; no automated migrations were required beyond the repository-level translation of historical tags.


### PR DESCRIPTION
## Summary
- rewrite the tag catalog planning note into a shipped summary that highlights storage, editing, runtime enforcement, and verification details
- mark the worklog entry as shipped and reference the permanent documentation alongside verification and migration notes

## Testing
- ./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.tags.TagCatalogRepositoryTest" --tests "li.crescio.penates.diana.tags.TagCatalogViewModelTest" --console=plain --no-daemon
- ./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.llm.MemoProcessorTest" --tests "li.crescio.penates.diana.ui.ThoughtsSectionUtilsTest" --console=plain --no-daemon


------
https://chatgpt.com/codex/tasks/task_e_68d2b906f5488325aea50ba8e8e81df3