### PR TITLE
docs: log firebase notes scripting plan

### DIFF
--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -6,6 +6,7 @@ This log captures active initiatives and recent pushes so contributors can orien
 
 | Date       | Status      | Summary | Further detail |
 | ---------- | ----------- | ------- | -------------- |
+| 2025-09-24 | In progress | Firebase notes scripting to backfill memo metadata and align Firestore exports with the memo processor. | [Firebase notes scripting plan](thoughts/firebase-notes-scripts.md) |
 | 2025-09-24 | Shipped     | Delete-session dialog polished with vertically stacked Material buttons to preserve touch targets. | Verified via Compose previews on phone and tablet widths. |
 | 2025-09-22 | In progress | Thought-document refactor: migrate memo processing to produce markdown bodies and navigation outlines, update persistence, and expose the richer structure in the UI. | [Thought document refactor plan](thoughts/thought-document-plan.md) |
 | 2025-09-25 | Shipped | Localized, user-managed tag catalog with offline cache, Firestore sync, and in-app tag editor. | [Localized tag catalog summary](thoughts/tag-catalog-plan.md) — Tests: TagCatalogRepositoryTest, TagCatalogViewModelTest, MemoProcessorTest, ThoughtsSectionUtilsTest. Migration: legacy `tags` strings auto-resolved by repository; no manual run needed. |

--- a/docs/thoughts/firebase-notes-scripts.md
+++ b/docs/thoughts/firebase-notes-scripts.md
@@ -1,0 +1,31 @@
+# Firebase notes scripting plan
+
+## Goals
+- Automate export and normalization of Firestore memo notes into the markdown format consumed by the memo processor.
+- Provide repeatable scripts to backfill historical note documents and reconcile missing memo metadata.
+- Enable scheduled execution so that the memo processor and Firestore stay in sync without manual intervention.
+
+## Assumptions
+- Service account credentials with read/write access to the `notes` and `memoMetadata` collections will be available via a CI secret.
+- Target collections include `notes`, `noteDrafts`, and `memoMetadata`, with scripts expected to operate primarily on `notes` and mirror updates into the other collections when necessary.
+- Memo-processing parity requires the scripts to reuse the same parsing rules and markdown emitters already defined in the memo processor service, either by importing shared libraries or by running in the same container image.
+
+## Risks
+- Divergent schema versions between historical documents and current memo processor expectations could cause data loss or require complex migration logic.
+- Service account quotas or permission misconfiguration may block bulk backfills and require batching strategies.
+- Running scripts without dry-run safeguards could overwrite user edits or cause duplicate memo metadata.
+
+## Open questions
+- Should the scripts live alongside existing memo processor tooling or as standalone Firestore utilities?
+- What telemetry or logging is required to verify each run and integrate with existing observability dashboards?
+- Do we need throttling or exponential backoff to comply with Firestore rate limits during large backfills?
+
+## Outcomes
+- Implementation planning is complete; scripting work is queued behind memo processor refactors and has not been executed yet.
+
+## Follow-ups
+- Build Firestore automation scripts that satisfy the parity goals outlined above and validate against staging data sets.
+- Define dry-run and logging strategies before the first production execution.
+
+## Deviations
+- No deviations from the planning assumptions so far; service account provisioning and schema verification still need confirmation during implementation.


### PR DESCRIPTION
## Summary
- add an in-progress worklog entry for the Firebase notes scripting initiative
- draft a planning memo capturing goals, assumptions, risks, and open questions for the Firebase notes scripts
- document current outcomes, follow-ups, and deviations in the memo as a baseline for the upcoming implementation

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d3a3e5446083258cedae06a0b7b294