### PR TITLE
Add reusable notes tooling for scripts

### DIFF
--- a/scripts/notes_tools/__init__.py
+++ b/scripts/notes_tools/__init__.py
@@ -1,0 +1,54 @@
+"""Utilities for working with remote notes and memo summaries."""
+
+try:
+    from .firebase import initialize_firestore
+except ModuleNotFoundError as exc:
+    def initialize_firestore(*args, **kwargs):
+        raise ModuleNotFoundError("firebase_admin is required for Firestore access") from exc
+
+from .notes import (
+    Appointment,
+    LocalizedLabel,
+    MemoSummary,
+    NoteCollection,
+    NotesTagCatalog,
+    NotesTagDefinition,
+    Session,
+    SessionSettings,
+    StructuredNote,
+    Thought,
+    ThoughtDocument,
+    ThoughtOutline,
+    ThoughtOutlineSection,
+    TodoItem,
+    parse_remote_note,
+    parse_remote_session,
+    resolve_tag_data,
+    summary_to_notes,
+)
+from .memo_processing import MemoProcessor, Prompts, load_resource
+
+__all__ = [
+    "initialize_firestore",
+    "Appointment",
+    "LocalizedLabel",
+    "MemoSummary",
+    "NoteCollection",
+    "NotesTagCatalog",
+    "NotesTagDefinition",
+    "Session",
+    "SessionSettings",
+    "StructuredNote",
+    "Thought",
+    "ThoughtDocument",
+    "ThoughtOutline",
+    "ThoughtOutlineSection",
+    "TodoItem",
+    "parse_remote_note",
+    "parse_remote_session",
+    "resolve_tag_data",
+    "summary_to_notes",
+    "MemoProcessor",
+    "Prompts",
+    "load_resource",
+]

--- a/scripts/notes_tools/firebase.py
+++ b/scripts/notes_tools/firebase.py
@@ -1,0 +1,51 @@
+"""Firebase helpers shared by note-management scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import firebase_admin
+from firebase_admin import App, credentials, firestore
+
+
+def _normalize_service_account(path: str | Path) -> Path:
+    candidate = Path(path).expanduser()
+    if not candidate.is_file():
+        raise FileNotFoundError(f"Service account key not found: {candidate}")
+    return candidate
+
+
+def initialize_app(
+    service_account: str | Path,
+    project_id: str | None = None,
+    *,
+    app_name: str | None = None,
+) -> App:
+    """Initialise a Firebase Admin app if one has not already been created."""
+
+    name = app_name or firebase_admin._DEFAULT_APP_NAME  # type: ignore[attr-defined]
+    try:
+        return firebase_admin.get_app(name)
+    except ValueError:
+        key_path = _normalize_service_account(service_account)
+        cred = credentials.Certificate(key_path)
+        options: Mapping[str, Any] | None = None
+        if project_id:
+            options = {"projectId": project_id}
+        return firebase_admin.initialize_app(cred, options, name=name)
+
+
+def initialize_firestore(
+    service_account: str | Path,
+    project_id: str | None = None,
+    *,
+    app_name: str | None = None,
+) -> firestore.Client:
+    """Create (or reuse) a Firestore client bound to the configured app."""
+
+    app = initialize_app(service_account, project_id, app_name=app_name)
+    return firestore.client(app=app)
+
+
+__all__ = ["initialize_app", "initialize_firestore"]

--- a/scripts/notes_tools/memo_processing.py
+++ b/scripts/notes_tools/memo_processing.py
@@ -1,0 +1,518 @@
+"""Python port of the Android memo processing pipeline."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping, Sequence
+
+from .notes import (
+    Appointment,
+    MemoSummary,
+    NotesTagCatalog,
+    NotesTagDefinition,
+    TagMappingContext,
+    Thought,
+    ThoughtDocument,
+    ThoughtOutline,
+    ThoughtOutlineSection,
+    TodoItem,
+)
+
+RESOURCE_ROOT = Path(__file__).resolve().parents[2] / "app" / "src" / "main" / "resources" / "llm"
+
+
+def load_resource(path: str, root: Path | None = None) -> str:
+    """Load a text asset from the LLM resources directory."""
+
+    trimmed = path.strip()
+    if not trimmed:
+        raise ValueError("Empty resource path")
+    normalized = trimmed.lstrip("/")
+    if normalized.startswith("llm/"):
+        normalized = normalized[4:]
+    candidate = PurePosixPath(normalized)
+    if any(part == ".." for part in candidate.parts):
+        raise ValueError(f"Invalid resource path: {path}")
+    base = root or RESOURCE_ROOT
+    target = base.joinpath(*candidate.parts)
+    return target.read_text(encoding="utf-8")
+
+
+@dataclass(slots=True)
+class Prompts:
+    todo: str
+    appointments: str
+    thoughts: str
+    system_template: str
+    user_template: str
+
+    @classmethod
+    def for_locale(cls, locale: str, root: Path | None = None) -> "Prompts":
+        language = locale.split("-")[0].lower()
+        if language not in {"en", "it", "fr"}:
+            language = "en"
+
+        def _load(name: str) -> str:
+            return load_resource(f"llm/prompts/{language}/{name}.txt", root).strip()
+
+        return cls(
+            todo=_load("todo"),
+            appointments=_load("appointments"),
+            thoughts=_load("thoughts"),
+            system_template=_load("system"),
+            user_template=_load("user"),
+        )
+
+
+@dataclass(slots=True)
+class LlmLogger:
+    max_entries: int = 100
+    _entries: list[str] = field(default_factory=list)
+
+    def log(self, request: str, response: str) -> None:
+        entry = f"REQUEST: {request}\nRESPONSE: {response}"
+        self._entries.append(entry)
+        if len(self._entries) > self.max_entries:
+            del self._entries[0]
+
+    def entries(self) -> list[str]:
+        return list(self._entries)
+
+
+@dataclass(slots=True)
+class TagDescriptor:
+    id: str
+    label: str
+
+
+@dataclass(slots=True)
+class TagCatalogSnapshot:
+    descriptors: list[TagDescriptor]
+    approved_ids: set[str]
+    prompt_text: str
+    primary_tag_id: str | None
+
+    @classmethod
+    def from_catalog(cls, catalog: NotesTagCatalog | None, locale: str) -> "TagCatalogSnapshot":
+        if catalog is None or not catalog.tags:
+            return cls([], set(), "- (no tags available)", None)
+        descriptors: list[TagDescriptor] = []
+        approved: list[str] = []
+        for definition in catalog.tags:
+            tag_id = definition.id.strip()
+            if not tag_id:
+                continue
+            label = definition.label_for_locale(locale) or (
+                definition.labels[0].value if definition.labels else tag_id
+            )
+            descriptors.append(TagDescriptor(tag_id, label))
+            approved.append(tag_id)
+        unique: dict[str, TagDescriptor] = {}
+        for descriptor in descriptors:
+            unique.setdefault(descriptor.id, descriptor)
+        descriptors = sorted(
+            unique.values(),
+            key=lambda item: (item.label.lower(), item.id.lower()),
+        )
+        prompt = "\n".join(f"- {descriptor.id}: {descriptor.label}" for descriptor in descriptors)
+        return cls(descriptors, set(approved), prompt, descriptors[0].id if descriptors else None)
+
+
+def available_model_ids(root: Path | None = None) -> list[str]:
+    try:
+        raw = load_resource("llm/models.json", root)
+    except FileNotFoundError:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    ids: list[str] = []
+    seen: set[str] = set()
+    for entry in parsed:
+        if not isinstance(entry, Mapping):
+            continue
+        identifier = str(entry.get("id", "")).strip()
+        if identifier and identifier not in seen:
+            ids.append(identifier)
+            seen.add(identifier)
+    return ids
+
+
+class MemoProcessor:
+    """Stateless interface for constructing memo update requests."""
+
+    DEFAULT_MODEL = "mistralai/mistral-nemo"
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        locale: str = "en",
+        logger: LlmLogger | None = None,
+        root: Path | None = None,
+        tag_catalog: NotesTagCatalog | None = None,
+    ) -> None:
+        self.api_key = api_key
+        self.locale = locale
+        self.root = root
+        self.prompts = Prompts.for_locale(locale, root)
+        self.logger = logger or LlmLogger()
+        self.base_schema = json.loads(load_resource("llm/schema/base.json", root))
+        self.todo_schema = json.loads(load_resource("llm/schema/todo.json", root))
+        self.appointment_schema = json.loads(load_resource("llm/schema/appointment.json", root))
+        self.thought_schema = json.loads(load_resource("llm/schema/thought.json", root))
+        self.tag_catalog_snapshot = TagCatalogSnapshot.from_catalog(tag_catalog, locale)
+        self.todo: str = ""
+        self.todo_items: list[TodoItem] = []
+        self.appointments: str = ""
+        self.appointment_items: list[Appointment] = []
+        self.thoughts: str = ""
+        self.thought_items: list[Thought] = []
+        self.thought_document: ThoughtDocument | None = None
+        self._pending_requests: dict[str, str] = {}
+        self._model = self._normalize_model(self.DEFAULT_MODEL)
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @model.setter
+    def model(self, value: str) -> None:
+        self._model = self._normalize_model(value)
+
+    def _normalize_model(self, candidate: str) -> str:
+        available = available_model_ids(self.root)
+        if not available:
+            return candidate or self.DEFAULT_MODEL
+        if candidate in available:
+            return candidate
+        if self.DEFAULT_MODEL in available:
+            return self.DEFAULT_MODEL
+        return available[0]
+
+    def update_tag_catalog(self, catalog: NotesTagCatalog | None) -> None:
+        self.tag_catalog_snapshot = TagCatalogSnapshot.from_catalog(catalog, self.locale)
+        self.todo_items = self._sanitize_todo_items(self.todo_items)
+        self.thought_items = self._sanitize_thought_items(self.thought_items)
+
+    def initialize(self, summary: MemoSummary) -> None:
+        self.todo = summary.todo
+        self.todo_items = self._sanitize_todo_items(summary.todo_items)
+        self.appointments = summary.appointments
+        self.appointment_items = [
+            Appointment(text=item.text, datetime=item.datetime, location=item.location, created_at=item.created_at)
+            for item in summary.appointment_items
+        ]
+        self.thoughts = summary.thought_document.markdown_body if summary.thought_document else summary.thoughts
+        self.thought_items = self._sanitize_thought_items(summary.thought_items)
+        self.thought_document = summary.thought_document
+
+    def prepare_requests(
+        self,
+        memo_text: str,
+        *,
+        process_todos: bool = True,
+        process_appointments: bool = True,
+        process_thoughts: bool = True,
+    ) -> dict[str, dict[str, Any]]:
+        if not self.api_key:
+            raise ValueError("Missing API key")
+        requests: dict[str, dict[str, Any]] = {}
+        if process_todos:
+            prior = self._todo_prior_json()
+            payload = self._build_request(self.prompts.todo, prior, memo_text)
+            requests[self.prompts.todo] = payload
+            self._pending_requests[self.prompts.todo] = json.dumps(payload, ensure_ascii=False)
+        if process_appointments:
+            prior = self._appointment_prior_json()
+            payload = self._build_request(self.prompts.appointments, prior, memo_text)
+            requests[self.prompts.appointments] = payload
+            self._pending_requests[self.prompts.appointments] = json.dumps(payload, ensure_ascii=False)
+        if process_thoughts:
+            prior = self._thought_prior_json()
+            payload = self._build_request(self.prompts.thoughts, prior, memo_text)
+            requests[self.prompts.thoughts] = payload
+            self._pending_requests[self.prompts.thoughts] = json.dumps(payload, ensure_ascii=False)
+        return requests
+
+    def ingest_response(self, aspect: str, response_body: str) -> str:
+        if aspect not in self._pending_requests:
+            raise KeyError(f"No pending request for aspect '{aspect}'")
+        request = self._pending_requests.pop(aspect)
+        self.logger.log(request, response_body)
+        return self._apply_response(aspect, response_body)
+
+    def summary(self) -> MemoSummary:
+        return MemoSummary(
+            todo=self.todo,
+            appointments=self.appointments,
+            thoughts=self.thoughts,
+            todo_items=self.todo_items,
+            appointment_items=self.appointment_items,
+            thought_items=self.thought_items,
+            thought_document=self.thought_document,
+        )
+
+    def _sanitize_todo_items(self, items: Iterable[TodoItem]) -> list[TodoItem]:
+        sanitized: list[TodoItem] = []
+        for item in items:
+            sanitized.append(
+                TodoItem(
+                    text=item.text.strip(),
+                    status=item.status.strip(),
+                    tag_ids=self._sanitize_tag_ids(item.tag_ids),
+                    tag_labels=list(item.tag_labels),
+                    due_date=item.due_date.strip(),
+                    event_date=item.event_date.strip(),
+                    note_id=item.note_id,
+                    created_at=item.created_at,
+                )
+            )
+        return sanitized
+
+    def _sanitize_thought_items(self, items: Iterable[Thought]) -> list[Thought]:
+        sanitized: list[Thought] = []
+        for item in items:
+            sanitized.append(
+                Thought(
+                    text=item.text.strip(),
+                    tag_ids=self._sanitize_tag_ids(item.tag_ids),
+                    tag_labels=list(item.tag_labels),
+                    section_anchor=item.section_anchor,
+                    section_title=item.section_title,
+                    created_at=item.created_at,
+                )
+            )
+        return sanitized
+
+    def _sanitize_tag_ids(self, ids: Sequence[str]) -> list[str]:
+        sanitized: list[str] = []
+        for raw in ids:
+            trimmed = raw.strip()
+            if not trimmed:
+                continue
+            if self.tag_catalog_snapshot.approved_ids and trimmed not in self.tag_catalog_snapshot.approved_ids:
+                continue
+            if trimmed not in sanitized:
+                sanitized.append(trimmed)
+        if not sanitized and self.tag_catalog_snapshot.primary_tag_id:
+            sanitized.append(self.tag_catalog_snapshot.primary_tag_id)
+        return sanitized
+
+    def _todo_prior_json(self) -> str:
+        items = []
+        self.todo_items = self._sanitize_todo_items(self.todo_items)
+        for item in self.todo_items:
+            items.append(
+                {
+                    "text": item.text,
+                    "status": item.status,
+                    "tags": item.tag_ids,
+                    "due_date": item.due_date or None,
+                    "event_date": item.event_date or None,
+                    "id": item.note_id or None,
+                }
+            )
+        payload = {"items": items}
+        return json.dumps(payload, ensure_ascii=False)
+
+    def _appointment_prior_json(self) -> str:
+        entries = [
+            {"text": item.text, "datetime": item.datetime, "location": item.location}
+            for item in self.appointment_items
+        ]
+        payload = {"updated": self.appointments, "items": entries}
+        return json.dumps(payload, ensure_ascii=False)
+
+    def _thought_prior_json(self) -> str:
+        self.thought_items = self._sanitize_thought_items(self.thought_items)
+        sections = []
+        if self.thought_document:
+            sections = [self._outline_section_to_dict(section) for section in self.thought_document.outline.sections]
+        payload = {
+            "markdown_body": self.thought_document.markdown_body if self.thought_document else self.thoughts,
+            "sections": sections,
+            "items": [
+                {"text": item.text, "tags": item.tag_ids}
+                for item in self.thought_items
+            ],
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+    def _outline_section_to_dict(self, section: ThoughtOutlineSection) -> dict[str, Any]:
+        return {
+            "title": section.title,
+            "level": section.level,
+            "anchor": section.anchor,
+            "children": [self._outline_section_to_dict(child) for child in section.children],
+        }
+
+    def _build_request(self, aspect: str, prior_json: str, memo_text: str) -> dict[str, Any]:
+        if aspect == self.prompts.todo:
+            schema = json.loads(json.dumps(self.todo_schema))
+        elif aspect == self.prompts.appointments:
+            schema = json.loads(json.dumps(self.appointment_schema))
+        elif aspect == self.prompts.thoughts:
+            schema = json.loads(json.dumps(self.thought_schema))
+        else:
+            schema = json.loads(json.dumps(self.base_schema))
+        self._apply_tag_enumeration(aspect, schema)
+        system = self.prompts.system_template.replace("{aspect}", aspect)
+        user = (
+            self.prompts.user_template
+            .replace("{aspect}", aspect)
+            .replace("{prior}", prior_json)
+            .replace("{memo}", memo_text)
+            .replace("{today}", date.today().isoformat())
+            .replace("{tag_catalog}", self.tag_catalog_snapshot.prompt_text)
+        )
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "response_format": {"type": "json_schema", "json_schema": schema},
+        }
+        return payload
+
+    def _apply_response(self, aspect: str, response_body: str) -> str:
+        data = json.loads(response_body)
+        if aspect == self.prompts.todo:
+            return self._apply_todo_response(data)
+        if aspect == self.prompts.appointments:
+            return self._apply_appointment_response(data)
+        if aspect == self.prompts.thoughts:
+            return self._apply_thought_response(data)
+        return data.get("updated", "") if isinstance(data, Mapping) else ""
+
+    def _apply_todo_response(self, data: Mapping[str, Any]) -> str:
+        items = []
+        updates = data.get("items")
+        if isinstance(updates, Sequence):
+            for entry in updates:
+                if not isinstance(entry, Mapping):
+                    continue
+                text = str(entry.get("text", "")).strip()
+                if not text:
+                    continue
+                status = str(entry.get("status", "")).strip()
+                tags = entry.get("tags") if isinstance(entry.get("tags"), Sequence) else []
+                due_date = str(entry.get("due_date", "")).strip()
+                event_date = str(entry.get("event_date", "")).strip()
+                note_id = str(entry.get("id", "")).strip()
+                items.append(
+                    TodoItem(
+                        text=text,
+                        status=status,
+                        tag_ids=self._sanitize_tag_ids([str(tag) for tag in tags]),
+                        due_date=due_date,
+                        event_date=event_date,
+                        note_id=note_id,
+                    )
+                )
+        existing = {item.note_id or item.text: item for item in self.todo_items}
+        for item in items:
+            key = item.note_id or item.text
+            existing[key] = item
+        self.todo_items = self._sanitize_todo_items(existing.values())
+        self.todo = "\n".join(item.text for item in self.todo_items if item.text)
+        return self.todo
+
+    def _apply_appointment_response(self, data: Mapping[str, Any]) -> str:
+        updated = str(data.get("updated", self.appointments))
+        items: list[Appointment] = []
+        entries = data.get("items")
+        if isinstance(entries, Sequence):
+            for entry in entries:
+                if not isinstance(entry, Mapping):
+                    continue
+                text = str(entry.get("text", "")).strip()
+                if not text:
+                    continue
+                datetime_str = str(entry.get("datetime", "")).strip()
+                location = str(entry.get("location", "")).strip()
+                items.append(Appointment(text=text, datetime=datetime_str, location=location))
+        self.appointment_items = items
+        self.appointments = updated
+        return self.appointments
+
+    def _apply_thought_response(self, data: Mapping[str, Any]) -> str:
+        items: list[Thought] = []
+        entries = data.get("items")
+        if isinstance(entries, Sequence):
+            for entry in entries:
+                if not isinstance(entry, Mapping):
+                    continue
+                text = str(entry.get("text", "")).strip()
+                if not text:
+                    continue
+                tags = entry.get("tags") if isinstance(entry.get("tags"), Sequence) else []
+                items.append(
+                    Thought(
+                        text=text,
+                        tag_ids=self._sanitize_tag_ids([str(tag) for tag in tags]),
+                        created_at=0,
+                    )
+                )
+        updated = str(data.get("updated_markdown", self.thoughts))
+        sections = self._parse_outline_sections(data.get("sections"))
+        self.thought_document = ThoughtDocument(updated, ThoughtOutline(sections))
+        self.thought_items = self._sanitize_thought_items(items)
+        self.thoughts = updated
+        return self.thoughts
+
+    def _parse_outline_sections(self, value: Any) -> list[ThoughtOutlineSection]:
+        if not isinstance(value, Sequence):
+            return []
+        sections: list[ThoughtOutlineSection] = []
+        for entry in value:
+            if not isinstance(entry, Mapping):
+                continue
+            title = str(entry.get("title", "")).strip()
+            if not title:
+                continue
+            level = int(entry.get("level", 1))
+            anchor = str(entry.get("anchor", "")).strip() or self._default_anchor(title)
+            children = self._parse_outline_sections(entry.get("children"))
+            sections.append(ThoughtOutlineSection(title, level, anchor, children))
+        return sections
+
+    def _default_anchor(self, title: str) -> str:
+        slug = "".join(ch for ch in title.lower() if ch.isalnum() or ch.isspace()).strip().replace(" ", "-")
+        return slug or f"section-{abs(hash(title)) & 0xFFFF:x}"
+
+    def _apply_tag_enumeration(self, aspect: str, schema_object: dict[str, Any]) -> None:
+        if aspect not in {self.prompts.todo, self.prompts.thoughts}:
+            return
+        target = schema_object.get("schema")
+        if not isinstance(target, dict):
+            target = schema_object
+        cursor: dict[str, Any] | None = target
+        path = ["properties", "items", "items", "properties", "tags", "items"]
+        for segment in path[:-1]:
+            next_obj = cursor.get(segment) if isinstance(cursor, dict) else None
+            if not isinstance(next_obj, dict):
+                return
+            cursor = next_obj
+        final = cursor.get(path[-1]) if isinstance(cursor, dict) else None
+        if not isinstance(final, dict):
+            return
+        final.pop("pattern", None)
+        if self.tag_catalog_snapshot.descriptors:
+            final["enum"] = [descriptor.id for descriptor in self.tag_catalog_snapshot.descriptors]
+        else:
+            final.pop("enum", None)
+
+
+__all__ = [
+    "LlmLogger",
+    "MemoProcessor",
+    "Prompts",
+    "available_model_ids",
+    "load_resource",
+]

--- a/scripts/notes_tools/notes.py
+++ b/scripts/notes_tools/notes.py
@@ -1,0 +1,534 @@
+"""Dataclasses and helpers for working with sessions and structured notes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+DocumentData = Mapping[str, Any]
+
+
+def _as_string_sequence(value: Any) -> list[str]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [str(item) for item in value]
+    return []
+
+
+@dataclass(slots=True)
+class SessionSettings:
+    process_todos: bool = True
+    process_appointments: bool = True
+    process_thoughts: bool = True
+    model: str = ""
+
+    @classmethod
+    def from_remote(cls, data: Mapping[str, Any] | None) -> "SessionSettings":
+        if data is None:
+            return cls()
+
+        def parse_bool(value: Any, default: bool) -> bool:
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, (int, float)):
+                return bool(int(value))
+            if isinstance(value, str):
+                lowered = value.strip().lower()
+                if lowered in {"true", "1", "yes"}:
+                    return True
+                if lowered in {"false", "0", "no"}:
+                    return False
+            return default
+
+        return cls(
+            process_todos=parse_bool(
+                data.get("processTodos", data.get("saveTodos")), True
+            ),
+            process_appointments=parse_bool(
+                data.get("processAppointments", data.get("saveAppointments")), True
+            ),
+            process_thoughts=parse_bool(
+                data.get("processThoughts", data.get("saveThoughts")), True
+            ),
+            model=str(data.get("model", "")).strip(),
+        )
+
+    def to_map(self) -> dict[str, Any]:
+        return {
+            "processTodos": self.process_todos,
+            "processAppointments": self.process_appointments,
+            "processThoughts": self.process_thoughts,
+            "model": self.model,
+        }
+
+
+@dataclass(slots=True)
+class Session:
+    id: str
+    name: str
+    settings: SessionSettings
+
+    def to_map(self) -> dict[str, Any]:
+        return {"name": self.name, "settings": self.settings.to_map()}
+
+
+def _document_payload(document: Any) -> tuple[str, DocumentData]:
+    if hasattr(document, "to_dict"):
+        data = document.to_dict() or {}
+    elif isinstance(document, Mapping):
+        data = dict(document)
+    else:
+        raise TypeError("Unsupported document type")
+
+    if hasattr(document, "id"):
+        doc_id = getattr(document, "id")
+    else:
+        doc_id = data.get("id")
+    if doc_id is None or str(doc_id).strip() == "":
+        raise ValueError("Document is missing an identifier")
+    return str(doc_id), data
+
+
+def parse_remote_session(document: Any) -> Session | None:
+    doc_id, data = _document_payload(document)
+    name = str(data.get("name", "")).strip()
+    if not name:
+        return None
+    settings_data = data.get("settings") if isinstance(data.get("settings"), Mapping) else None
+    settings = SessionSettings.from_remote(settings_data)
+    return Session(doc_id, name, settings)
+
+
+@dataclass(slots=True)
+class LocalizedLabel:
+    locale_tag: str | None
+    value: str
+
+    @property
+    def normalized_tag(self) -> str | None:
+        if self.locale_tag is None:
+            return None
+        normalized = self.locale_tag.replace("_", "-").strip().lower()
+        return normalized or None
+
+    @classmethod
+    def from_mapping(cls, locale_tag: str | None, value: str) -> "LocalizedLabel":
+        return cls(locale_tag if locale_tag else None, value)
+
+
+@dataclass(slots=True)
+class NotesTagDefinition:
+    id: str
+    labels: list[LocalizedLabel]
+    color: str | None = None
+
+    def label_for_locale(self, locale: str) -> str | None:
+        if not self.labels:
+            return None
+        normalized_locale = locale.replace("_", "-").lower()
+        by_tag: dict[str, str] = {}
+        default_label: str | None = None
+        for label in self.labels:
+            tag = label.normalized_tag
+            if tag is None:
+                default_label = default_label or label.value
+            elif tag not in by_tag:
+                by_tag[tag] = label.value
+        if normalized_locale in by_tag:
+            return by_tag[normalized_locale]
+        language = normalized_locale.split("-")[0]
+        return by_tag.get(language) or default_label or self.labels[0].value
+
+    @classmethod
+    def from_map(cls, data: Mapping[str, Any]) -> "NotesTagDefinition":
+        raw_labels = data.get("labels")
+        labels: list[LocalizedLabel] = []
+        if isinstance(raw_labels, Mapping):
+            for key, value in raw_labels.items():
+                if not isinstance(value, str):
+                    continue
+                locale_tag = None if key == "default" else key
+                labels.append(LocalizedLabel.from_mapping(locale_tag, value))
+        return cls(str(data.get("id", "")).strip(), labels, data.get("color"))
+
+
+@dataclass(slots=True)
+class NotesTagCatalog:
+    tags: list[NotesTagDefinition] = field(default_factory=list)
+
+    @classmethod
+    def from_map(cls, data: Mapping[str, Any] | None) -> "NotesTagCatalog":
+        if not data:
+            return cls([])
+        raw_tags = data.get("tags")
+        tags: list[NotesTagDefinition] = []
+        if isinstance(raw_tags, Sequence):
+            for entry in raw_tags:
+                if isinstance(entry, Mapping):
+                    tag_id = str(entry.get("id", "")).strip()
+                    if not tag_id:
+                        continue
+                    labels = []
+                    raw_labels = entry.get("labels")
+                    if isinstance(raw_labels, Mapping):
+                        for key, value in raw_labels.items():
+                            if not isinstance(value, str):
+                                continue
+                            locale_tag = None if key == "default" else key
+                            labels.append(LocalizedLabel.from_mapping(locale_tag, value))
+                    tags.append(
+                        NotesTagDefinition(
+                            id=tag_id,
+                            labels=labels or [LocalizedLabel(None, tag_id)],
+                            color=(entry.get("color") if isinstance(entry.get("color"), str) else None),
+                        )
+                    )
+        return cls(tags)
+
+
+@dataclass(slots=True)
+class ThoughtOutlineSection:
+    title: str
+    level: int
+    anchor: str
+    children: list["ThoughtOutlineSection"] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ThoughtOutline:
+    sections: list[ThoughtOutlineSection]
+
+    @classmethod
+    def empty(cls) -> "ThoughtOutline":
+        return cls([])
+
+
+@dataclass(slots=True)
+class ThoughtDocument:
+    markdown_body: str
+    outline: ThoughtOutline = field(default_factory=ThoughtOutline.empty)
+
+
+@dataclass(slots=True)
+class StructuredNote:
+    created_at: int = 0
+
+
+@dataclass(slots=True)
+class TodoItem(StructuredNote):
+    text: str = ""
+    status: str = ""
+    tag_ids: list[str] = field(default_factory=list)
+    tag_labels: list[str] = field(default_factory=list)
+    due_date: str = ""
+    event_date: str = ""
+    note_id: str = ""
+
+
+@dataclass(slots=True)
+class Thought(StructuredNote):
+    text: str = ""
+    tag_ids: list[str] = field(default_factory=list)
+    tag_labels: list[str] = field(default_factory=list)
+    section_anchor: str | None = None
+    section_title: str | None = None
+
+
+@dataclass(slots=True)
+class Appointment(StructuredNote):
+    text: str = ""
+    datetime: str = ""
+    location: str = ""
+
+
+@dataclass(slots=True)
+class FreeNote(StructuredNote):
+    text: str = ""
+    tag_ids: list[str] = field(default_factory=list)
+    tag_labels: list[str] = field(default_factory=list)
+
+
+StructuredNoteType = TodoItem | Thought | Appointment | FreeNote
+
+
+@dataclass(slots=True)
+class NoteCollection:
+    notes: list[StructuredNoteType]
+
+
+@dataclass(slots=True)
+class MemoSummary:
+    todo: str
+    appointments: str
+    thoughts: str
+    todo_items: list[TodoItem]
+    appointment_items: list[Appointment]
+    thought_items: list[Thought]
+    thought_document: ThoughtDocument | None = None
+
+
+def _sanitize_strings(values: Iterable[str]) -> list[str]:
+    seen: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        trimmed = value.strip()
+        if trimmed and trimmed not in seen:
+            seen.append(trimmed)
+    return seen
+
+
+@dataclass(slots=True)
+class TagMigrationResult:
+    tag_ids: list[str]
+    unresolved_labels: list[str]
+
+
+@dataclass(slots=True)
+class TagMappingContext:
+    catalog: NotesTagCatalog | None
+    locale: str
+    _canonical_ids: set[str] = field(init=False, default_factory=set)
+    _id_lookup: dict[str, str] = field(init=False, default_factory=dict)
+    _label_lookup: dict[str, str] = field(init=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        ids: list[str] = []
+        id_lookup: dict[str, str] = {}
+        label_lookup: dict[str, str] = {}
+        if self.catalog:
+            for definition in self.catalog.tags:
+                tag_id = definition.id.strip()
+                if not tag_id:
+                    continue
+                if tag_id not in ids:
+                    ids.append(tag_id)
+                id_lookup.setdefault(tag_id.lower(), tag_id)
+                preferred = definition.label_for_locale(self.locale)
+                if preferred:
+                    label_lookup.setdefault(preferred.strip().lower(), tag_id)
+                for label in definition.labels:
+                    normalized = (label.value or "").strip().lower()
+                    if normalized:
+                        label_lookup.setdefault(normalized, tag_id)
+        self._canonical_ids = set(ids)
+        self._id_lookup = id_lookup
+        self._label_lookup = label_lookup
+
+    def map_legacy(self, legacy: Sequence[str]) -> TagMigrationResult:
+        resolved: list[str] = []
+        unresolved: list[str] = []
+        for raw in legacy:
+            candidate = self._resolve(raw)
+            if candidate:
+                if candidate not in resolved:
+                    resolved.append(candidate)
+            else:
+                trimmed = raw.strip()
+                if trimmed:
+                    unresolved.append(trimmed)
+        return TagMigrationResult(resolved, unresolved)
+
+    def _resolve(self, value: str) -> str | None:
+        trimmed = value.strip()
+        if not trimmed:
+            return None
+        if trimmed in self._canonical_ids:
+            return trimmed
+        lower = trimmed.lower()
+        return self._id_lookup.get(lower) or self._label_lookup.get(lower)
+
+
+def resolve_tag_data(
+    explicit_ids: Sequence[str],
+    explicit_labels: Sequence[str],
+    legacy_tags: Sequence[str],
+    tag_context: TagMappingContext,
+) -> tuple[list[str], list[str]]:
+    ids = _sanitize_strings(explicit_ids)
+    labels = _sanitize_strings(explicit_labels)
+    legacy = _sanitize_strings(legacy_tags)
+    if not ids and legacy:
+        migrated = tag_context.map_legacy(legacy)
+        ids = migrated.tag_ids
+        labels.extend(label for label in migrated.unresolved_labels if label not in labels)
+    elif legacy:
+        migrated = tag_context.map_legacy(legacy)
+        for tag_id in migrated.tag_ids:
+            if tag_id not in ids:
+                ids.append(tag_id)
+        labels.extend(label for label in migrated.unresolved_labels if label not in labels)
+    return ids, labels
+
+
+def parse_remote_note(document: Any, tag_context: TagMappingContext) -> StructuredNoteType | None:
+    doc_id, data = _document_payload(document)
+    note_type = str(data.get("type", "")).strip().lower()
+    text = data.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return None
+    created_at = int(data.get("createdAt", 0) or 0)
+    tag_ids, tag_labels = resolve_tag_data(
+        explicit_ids=_as_string_sequence(data.get("tagIds")),
+        explicit_labels=_as_string_sequence(data.get("tagLabels")),
+        legacy_tags=_as_string_sequence(data.get("tags")),
+        tag_context=tag_context,
+    )
+
+    if note_type == "todo":
+        status = str(data.get("status", "")).strip()
+        due_date = str(data.get("dueDate", "")).strip()
+        event_date = str(data.get("eventDate", "")).strip()
+        return TodoItem(
+            text=text.strip(),
+            status=status,
+            tag_ids=tag_ids,
+            tag_labels=tag_labels,
+            due_date=due_date,
+            event_date=event_date,
+            note_id=doc_id,
+            created_at=created_at,
+        )
+    if note_type == "memo":
+        section_anchor = str(data.get("sectionAnchor", "")).strip() or None
+        section_title = str(data.get("sectionTitle", "")).strip() or None
+        return Thought(
+            text=text.strip(),
+            tag_ids=tag_ids,
+            tag_labels=tag_labels,
+            section_anchor=section_anchor,
+            section_title=section_title,
+            created_at=created_at,
+        )
+    if note_type == "event":
+        datetime = str(data.get("datetime", "")).strip()
+        location = str(data.get("location", "")).strip()
+        return Appointment(
+            text=text.strip(),
+            datetime=datetime,
+            location=location,
+            created_at=created_at,
+        )
+    if note_type == "free":
+        return FreeNote(
+            text=text.strip(),
+            tag_ids=tag_ids,
+            tag_labels=tag_labels,
+            created_at=created_at,
+        )
+    return None
+
+
+def structured_note_to_map(note: StructuredNoteType) -> dict[str, Any]:
+    if isinstance(note, TodoItem):
+        payload: dict[str, Any] = {
+            "type": "todo",
+            "text": note.text,
+            "status": note.status,
+            "tagIds": note.tag_ids,
+            "tagLabels": note.tag_labels,
+            "dueDate": note.due_date,
+            "eventDate": note.event_date,
+            "createdAt": note.created_at,
+        }
+        if note.note_id:
+            payload["id"] = note.note_id
+        return payload
+    if isinstance(note, Thought):
+        payload = {
+            "type": "memo",
+            "text": note.text,
+            "tagIds": note.tag_ids,
+            "tagLabels": note.tag_labels,
+            "sectionAnchor": note.section_anchor,
+            "sectionTitle": note.section_title,
+            "createdAt": note.created_at,
+        }
+        return payload
+    if isinstance(note, Appointment):
+        return {
+            "type": "event",
+            "text": note.text,
+            "datetime": note.datetime,
+            "location": note.location,
+            "createdAt": note.created_at,
+        }
+    if isinstance(note, FreeNote):
+        return {
+            "type": "free",
+            "text": note.text,
+            "tagIds": note.tag_ids,
+            "tagLabels": note.tag_labels,
+            "createdAt": note.created_at,
+        }
+    raise TypeError(f"Unsupported note type: {type(note)!r}")
+
+
+def summary_to_notes(
+    summary: MemoSummary,
+    save_todos: bool = True,
+    save_appointments: bool = True,
+    save_thoughts: bool = True,
+) -> list[StructuredNoteType]:
+    notes: list[StructuredNoteType] = []
+    if save_todos:
+        for item in summary.todo_items:
+            notes.append(
+                TodoItem(
+                    text=item.text,
+                    status=item.status,
+                    tag_ids=list(item.tag_ids),
+                    tag_labels=list(item.tag_labels),
+                    due_date=item.due_date,
+                    event_date=item.event_date,
+                    note_id=item.note_id,
+                    created_at=item.created_at,
+                )
+            )
+    if save_appointments:
+        for item in summary.appointment_items:
+            notes.append(
+                Appointment(
+                    text=item.text,
+                    datetime=item.datetime,
+                    location=item.location,
+                    created_at=item.created_at,
+                )
+            )
+    if save_thoughts:
+        for item in summary.thought_items:
+            notes.append(
+                Thought(
+                    text=item.text,
+                    tag_ids=list(item.tag_ids),
+                    tag_labels=list(item.tag_labels),
+                    section_anchor=item.section_anchor,
+                    section_title=item.section_title,
+                    created_at=item.created_at,
+                )
+            )
+    return notes
+
+
+__all__ = [
+    "Appointment",
+    "FreeNote",
+    "LocalizedLabel",
+    "MemoSummary",
+    "NoteCollection",
+    "NotesTagCatalog",
+    "NotesTagDefinition",
+    "Session",
+    "SessionSettings",
+    "StructuredNote",
+    "TagMappingContext",
+    "Thought",
+    "ThoughtDocument",
+    "ThoughtOutline",
+    "ThoughtOutlineSection",
+    "TodoItem",
+    "parse_remote_note",
+    "parse_remote_session",
+    "resolve_tag_data",
+    "structured_note_to_map",
+    "summary_to_notes",
+]

--- a/scripts/tests/test_notes_tools.py
+++ b/scripts/tests/test_notes_tools.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+
+from scripts.notes_tools.memo_processing import MemoProcessor
+from scripts.notes_tools.notes import (
+    LocalizedLabel,
+    NotesTagCatalog,
+    NotesTagDefinition,
+    Session,
+    TagMappingContext,
+    parse_remote_note,
+    parse_remote_session,
+)
+
+
+@dataclass
+class DummySnapshot:
+    doc_id: str
+    data: dict[str, object]
+
+    @property
+    def id(self) -> str:
+        return self.doc_id
+
+    def to_dict(self) -> dict[str, object]:
+        return dict(self.data)
+
+
+class NotesToolsTest(unittest.TestCase):
+    def test_parse_remote_session(self) -> None:
+        snapshot = DummySnapshot(
+            "session-1",
+            {
+                "name": " Weekly Review ",
+                "settings": {
+                    "processTodos": False,
+                    "saveAppointments": "true",
+                    "processThoughts": 0,
+                    "model": "custom-model",
+                },
+            },
+        )
+        session = parse_remote_session(snapshot)
+        self.assertIsInstance(session, Session)
+        self.assertEqual(session.id, "session-1")
+        self.assertEqual(session.name, "Weekly Review")
+        self.assertFalse(session.settings.process_todos)
+        self.assertTrue(session.settings.process_appointments)
+        self.assertFalse(session.settings.process_thoughts)
+        self.assertEqual(session.settings.model, "custom-model")
+
+    def test_parse_remote_note_with_tag_migration(self) -> None:
+        catalog = NotesTagCatalog(
+            tags=[
+                NotesTagDefinition(
+                    id="work",
+                    labels=[LocalizedLabel(locale_tag=None, value="Work")],
+                )
+            ]
+        )
+        context = TagMappingContext(catalog=catalog, locale="en")
+        snapshot = DummySnapshot(
+            "note-1",
+            {
+                "type": "todo",
+                "text": "Finish report",
+                "status": "in_progress",
+                "tags": ["Work", "Personal"],
+                "createdAt": 123,
+            },
+        )
+        note = parse_remote_note(snapshot, context)
+        self.assertIsNotNone(note)
+        self.assertEqual(getattr(note, "tag_ids"), ["work"])
+        self.assertIn("Personal", getattr(note, "tag_labels"))
+        self.assertEqual(getattr(note, "created_at"), 123)
+
+    def test_schema_injects_tag_catalog(self) -> None:
+        catalog = NotesTagCatalog(
+            tags=[
+                NotesTagDefinition(
+                    id="alpha",
+                    labels=[LocalizedLabel(locale_tag=None, value="Alpha")],
+                ),
+                NotesTagDefinition(
+                    id="beta",
+                    labels=[LocalizedLabel(locale_tag="en", value="Beta")],
+                ),
+            ]
+        )
+        processor = MemoProcessor(api_key="secret", tag_catalog=catalog)
+        requests = processor.prepare_requests("memo", process_appointments=False, process_thoughts=False)
+        self.assertIn(processor.prompts.todo, requests)
+        schema = requests[processor.prompts.todo]["response_format"]["json_schema"]
+        tags_enum = (
+            schema["schema"]["properties"]["items"]["items"]["properties"]["tags"]["items"]["enum"]
+        )
+        self.assertEqual(tags_enum, ["alpha", "beta"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `scripts/notes_tools` package that exposes Firebase helpers, data models, and memo utilities for CLI tooling
- port session and note parsing plus memo summary mapping into Python dataclasses for reuse outside Android
- reproduce the memo processing workflow, including resource loading, prompt construction, and tag-aware schema injection
- cover the new helpers with unit tests for session/note parsing and tag catalog enumeration

## Testing
- python -m unittest discover -s scripts/tests

------
https://chatgpt.com/codex/tasks/task_e_68d3aeda15b48325bf2e7e6995131c77