### PR TITLE
Allow app to start without auto session

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -43,6 +43,7 @@
     <string name="delete_session_message">Voulez-vous vraiment supprimer %1$s ?</string>
     <string name="session_actions">Options de session</string>
     <string name="no_sessions">Aucune session</string>
+    <string name="no_active_session_message">Créez une session pour commencer.</string>
     <string name="delete_memo_title">Supprimer le mémo</string>
     <string name="delete_memo_message">Voulez-vous vraiment supprimer ce mémo ?</string>
     <string name="manage_tags">Gérer les tags</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -43,6 +43,7 @@
     <string name="delete_session_message">Sei sicuro di voler eliminare %1$s?</string>
     <string name="session_actions">Opzioni sessione</string>
     <string name="no_sessions">Nessuna sessione</string>
+    <string name="no_active_session_message">Crea una sessione per iniziare.</string>
     <string name="delete_memo_title">Elimina memo</string>
     <string name="delete_memo_message">Sei sicuro di voler eliminare questo memo?</string>
     <string name="manage_tags">Gestisci tag</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="delete_session_remote_action">Delete on this device and from Firebase</string>
     <string name="session_actions">Session options</string>
     <string name="no_sessions">No sessions</string>
+    <string name="no_active_session_message">Create a session to get started.</string>
     <string name="delete_memo_title">Delete memo</string>
     <string name="delete_memo_message">Are you sure you want to delete this memo?</string>
     <string name="import_remote_sessions">Import sessions</string>


### PR DESCRIPTION
## Summary
- stop automatically creating a default session when the repository is empty
- add an empty state UI so users can create or import the first session on their own
- migrate legacy local and remote data when the first session is created and add localized copy for the empty-state message

## Testing
- ./gradlew --no-daemon --console=plain :app:assembleDebug *(fails: Installed Build Tools revision 34.0.0 is corrupted / missing AAPT in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d67f64b3e083259c6405ad2d91114a