### PR TITLE
Ensure MemoRepository handles nested memo file paths

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/persistence/MemoRepository.kt
+++ b/app/src/main/java/li/crescio/penates/diana/persistence/MemoRepository.kt
@@ -3,11 +3,20 @@ package li.crescio.penates.diana.persistence
 import li.crescio.penates.diana.notes.Memo
 import org.json.JSONObject
 import java.io.File
+import java.io.IOException
 
 class MemoRepository(private val file: File) {
     suspend fun addMemo(memo: Memo) {
         if (!file.exists()) {
-            file.createNewFile()
+            val parent = file.parentFile
+            if (parent != null && !parent.exists()) {
+                if (!parent.mkdirs() && !parent.exists()) {
+                    throw IOException("Unable to create directory: ${parent.absolutePath}")
+                }
+            }
+            if (!file.exists()) {
+                file.createNewFile()
+            }
         }
         file.appendText(toJson(memo) + "\n")
     }

--- a/app/src/test/java/li/crescio/penates/diana/persistence/MemoRepositoryTest.kt
+++ b/app/src/test/java/li/crescio/penates/diana/persistence/MemoRepositoryTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import java.io.File
+import kotlin.io.path.createTempDirectory
 
 class MemoRepositoryTest {
     private lateinit var file: File
@@ -29,6 +30,22 @@ class MemoRepositoryTest {
         repository.addMemo(Memo("two", "audio"))
         val memos = repository.loadMemos()
         assertEquals(listOf(Memo("one"), Memo("two", "audio")), memos)
+    }
+
+    @Test
+    fun addMemoCreatesMissingParentDirectories() = runBlocking {
+        val root = createTempDirectory(prefix = "memo_repo").toFile()
+        try {
+            val nestedFile = File(root, "nested/memos.txt")
+            val nestedRepository = MemoRepository(nestedFile)
+
+            nestedRepository.addMemo(Memo("nested memo"))
+
+            val memos = nestedRepository.loadMemos()
+            assertEquals(listOf(Memo("nested memo")), memos)
+        } finally {
+            root.deleteRecursively()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- create missing parent directories before writing memo data so nested storage locations work
- add a regression test to confirm memos persist when saved under a new subdirectory

## Testing
- `./gradlew :app:testDebugUnitTest --tests "li.crescio.penates.diana.ui.CalculateUrgencyColorTest"` *(fails: Android SDK Platform/Build-Tools installation is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e28e28aee08325b4197578944dcc7f