### PR TITLE
Fix Python scripts package imports for tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,7 @@
+"""Utility scripts and helpers for the Diana project."""
+
+# Expose the notes_tools namespace for convenience when these utilities are
+# used as a package.
+from . import notes_tools  # noqa: F401  (re-exported for package discovery)
+
+__all__ = ["notes_tools"]


### PR DESCRIPTION
## Summary
- add a package initializer for the `scripts` utilities so `scripts.notes_tools` can be imported
- configure pytest to add the project root to `PYTHONPATH` so the scripts tests run without manual env setup

## Testing
- `pytest scripts/tests/test_notes_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68e28e47fe888325abe6ddb543d0c89b