### PR TITLE
Add scaffold top bars to archive and tag screens

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/MemoArchiveScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/MemoArchiveScreen.kt
@@ -5,10 +5,16 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -37,41 +43,58 @@ fun MemoArchiveScreen(
         memos = memoRepository.loadMemos()
     }
 
-    Column(modifier = modifier.fillMaxSize()) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 16.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Button(onClick = onBack) { Text(stringResource(R.string.back)) }
-        }
-
-        LazyColumn(modifier = Modifier.weight(1f).padding(horizontal = 16.dp)) {
-            items(memos) { memo ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .combinedClickable(
-                            onClick = {},
-                            onLongClick = { memoPendingDeletion = memo }
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text(text = stringResource(R.string.memo_archive)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
                         )
-                        .padding(vertical = 8.dp)
-                ) {
-                    if (memo.audioPath != null) {
-                        Button(onClick = { player.play(memo.audioPath) }) {
-                            Text(stringResource(R.string.play))
-                        }
                     }
-                    Text(
-                        memo.text,
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .weight(1f)
+            ) {
+                items(memos) { memo ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier
-                            .weight(1f)
-                            .padding(start = 16.dp)
-                    )
-                    Button(onClick = { onReprocess(memo) }) {
-                        Text(stringResource(R.string.reprocess))
+                            .fillMaxWidth()
+                            .combinedClickable(
+                                onClick = {},
+                                onLongClick = { memoPendingDeletion = memo }
+                            )
+                            .padding(vertical = 8.dp)
+                    ) {
+                        if (memo.audioPath != null) {
+                            Button(onClick = { player.play(memo.audioPath) }) {
+                                Text(stringResource(R.string.play))
+                            }
+                        }
+                        Text(
+                            memo.text,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 16.dp)
+                        )
+                        Button(onClick = { onReprocess(memo) }) {
+                            Text(stringResource(R.string.reprocess))
+                        }
                     }
                 }
             }

--- a/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/SettingsScreen.kt
@@ -2,11 +2,17 @@ package li.crescio.penates.diana.ui
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.annotation.StringRes
 import androidx.compose.ui.Alignment
@@ -35,19 +41,26 @@ fun SettingsScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxSize()) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 16.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Button(onClick = onBack) { Text(stringResource(R.string.back)) }
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text(text = stringResource(R.string.settings)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                }
+            )
         }
-
+    ) { innerPadding ->
         Column(
             modifier = Modifier
-                .weight(1f)
+                .padding(innerPadding)
+                .fillMaxSize()
                 .padding(horizontal = 16.dp)
         ) {
             Text(

--- a/app/src/main/java/li/crescio/penates/diana/ui/TagCatalogScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/TagCatalogScreen.kt
@@ -14,14 +14,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -51,28 +54,30 @@ fun TagCatalogScreen(
     onSave: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        Box(modifier = Modifier.fillMaxWidth()) {
-            Button(
-                onClick = onBack,
-                modifier = Modifier.align(Alignment.CenterStart)
-            ) {
-                Text(stringResource(R.string.back))
-            }
-            Text(
-                text = stringResource(R.string.manage_tags),
-                style = MaterialTheme.typography.titleLarge,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.align(Alignment.Center)
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(text = stringResource(R.string.manage_tags)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                }
             )
         }
-
-        when {
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            when {
             state.isLoading -> {
                 Box(
                     modifier = Modifier


### PR DESCRIPTION
## Summary
- replace the manually placed back buttons in the archive, settings, and tag catalog screens with Material 3 top app bars
- wrap each screen in a Scaffold and route their main content through the Scaffold body to respect insets

## Testing
- ./gradlew -Dorg.gradle.console=plain :app:compileDebugKotlin *(fails: Installed Build Tools revision 34.0.0 is corrupted in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68e29ee19c4c83259017159ed82dcb1d