### PR TITLE
Refine log section theming

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/ui/LogSection.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/LogSection.kt
@@ -1,18 +1,17 @@
 package li.crescio.penates.diana.ui
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 
@@ -24,18 +23,21 @@ fun LogSection(logs: List<String>) {
             listState.scrollToItem(logs.lastIndex)
         }
     }
-    Box(
+    Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .height(120.dp)
-            .background(Color.Black)
+            .height(120.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 4.dp,
+        shape = MaterialTheme.shapes.medium
     ) {
         LazyColumn(state = listState, modifier = Modifier.padding(8.dp)) {
             items(logs) { log ->
                 Text(
                     log,
                     fontFamily = FontFamily.Monospace,
-                    color = Color.Green
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }


### PR DESCRIPTION
## Summary
- replace hard-coded log colors with values from `MaterialTheme.colorScheme`
- wrap the log feed in a surfaced container with elevation and shape
- apply body typography so log text respects user scaling

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e2c2e658fc8325bb89b8637b2f2691