### PR TITLE
Add splash screen with Diana illustration

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
+++ b/app/src/main/java/li/crescio/penates/diana/MainActivity.kt
@@ -54,6 +54,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthException
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.tasks.await
@@ -192,6 +193,11 @@ class MainActivity : ComponentActivity() {
                 }
             }
             setContent {
+                    var showSplash by remember { mutableStateOf(true) }
+                    LaunchedEffect(Unit) {
+                        delay(1200)
+                        showSplash = false
+                    }
                     var environment by remember { mutableStateOf<SessionEnvironment?>(initialEnvironment) }
                     val sessionsState = remember {
                         mutableStateListOf<Session>().apply { addAll(sessionRepository.list()) }
@@ -303,52 +309,56 @@ class MainActivity : ComponentActivity() {
                     }
 
                     DianaTheme {
-                        val activeEnvironment = environment
-                        if (activeEnvironment != null) {
-                            DianaApp(
-                                session = activeEnvironment.session,
-                                sessions = sessionsState,
-                                importableSessions = importableSessions,
-                                repository = activeEnvironment.noteRepository,
-                                memoRepository = activeEnvironment.memoRepository,
-                                tagCatalogRepository = activeEnvironment.tagCatalogRepository,
-                                onUpdateSession = { updatedSession ->
-                                    val persisted = sessionRepository.update(updatedSession)
-                                    environment = environment?.copy(session = persisted)
-                                    refreshSessions()
-                                    coroutineScope.launch {
-                                        try {
-                                            sessionRepository.syncSessionRemote(persisted)
-                                        } catch (e: Exception) {
-                                            Log.w(
-                                                "MainActivity",
-                                                "Failed to sync session ${persisted.id} to Firestore",
-                                                e,
-                                            )
-                                        }
-                                    }
-                                    persisted
-                                },
-                                onSwitchSession = switchSession,
-                                onAddSession = addSession,
-                                onRenameSession = renameSession,
-                                onDeleteSessionLocal = deleteSessionLocal,
-                                onDeleteSessionRemote = deleteSessionRemote,
-                                onImportRemoteSession = importRemoteSession,
-                                onRefreshImportableSessions = { refreshRemoteSessionsList() },
-                            )
+                        if (showSplash) {
+                            SplashScreen(modifier = Modifier.fillMaxSize())
                         } else {
-                            NoActiveSessionScreen(
-                                sessions = sessionsState,
-                                importableSessions = importableSessions,
-                                onSwitchSession = switchSession,
-                                onAddSession = addSession,
-                                onRenameSession = renameSession,
-                                onDeleteSessionLocal = deleteSessionLocal,
-                                onDeleteSessionRemote = deleteSessionRemote,
-                                onImportRemoteSession = importRemoteSession,
-                                onRefreshImportableSessions = { refreshRemoteSessionsList() },
-                            )
+                            val activeEnvironment = environment
+                            if (activeEnvironment != null) {
+                                DianaApp(
+                                    session = activeEnvironment.session,
+                                    sessions = sessionsState,
+                                    importableSessions = importableSessions,
+                                    repository = activeEnvironment.noteRepository,
+                                    memoRepository = activeEnvironment.memoRepository,
+                                    tagCatalogRepository = activeEnvironment.tagCatalogRepository,
+                                    onUpdateSession = { updatedSession ->
+                                        val persisted = sessionRepository.update(updatedSession)
+                                        environment = environment?.copy(session = persisted)
+                                        refreshSessions()
+                                        coroutineScope.launch {
+                                            try {
+                                                sessionRepository.syncSessionRemote(persisted)
+                                            } catch (e: Exception) {
+                                                Log.w(
+                                                    "MainActivity",
+                                                    "Failed to sync session ${persisted.id} to Firestore",
+                                                    e,
+                                                )
+                                            }
+                                        }
+                                        persisted
+                                    },
+                                    onSwitchSession = switchSession,
+                                    onAddSession = addSession,
+                                    onRenameSession = renameSession,
+                                    onDeleteSessionLocal = deleteSessionLocal,
+                                    onDeleteSessionRemote = deleteSessionRemote,
+                                    onImportRemoteSession = importRemoteSession,
+                                    onRefreshImportableSessions = { refreshRemoteSessionsList() },
+                                )
+                            } else {
+                                NoActiveSessionScreen(
+                                    sessions = sessionsState,
+                                    importableSessions = importableSessions,
+                                    onSwitchSession = switchSession,
+                                    onAddSession = addSession,
+                                    onRenameSession = renameSession,
+                                    onDeleteSessionLocal = deleteSessionLocal,
+                                    onDeleteSessionRemote = deleteSessionRemote,
+                                    onImportRemoteSession = importRemoteSession,
+                                    onRefreshImportableSessions = { refreshRemoteSessionsList() },
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/li/crescio/penates/diana/ui/SplashScreen.kt
+++ b/app/src/main/java/li/crescio/penates/diana/ui/SplashScreen.kt
@@ -1,0 +1,194 @@
+package li.crescio.penates.diana.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.graphics.vector.addPathNodes
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import li.crescio.penates.diana.BuildConfig
+import li.crescio.penates.diana.R
+import li.crescio.penates.diana.ui.theme.DianaTheme
+
+@Composable
+fun SplashScreen(
+    modifier: Modifier = Modifier,
+    versionName: String = BuildConfig.VERSION_NAME,
+) {
+    val backgroundBrush = remember {
+        Brush.radialGradient(
+            colors = listOf(
+                Color(0xFF100224),
+                Color(0xFF1D0842),
+                Color(0xFF2E1456),
+            ),
+            center = Offset.Zero,
+            radius = 900f,
+        )
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(backgroundBrush)
+            .padding(horizontal = 32.dp, vertical = 48.dp),
+    ) {
+        Surface(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxSize(),
+            color = Color.Transparent,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                val splashPainter = rememberVectorPainter(dianaHuntressVector)
+                val description = stringResource(R.string.splash_diana_content_description)
+                Image(
+                    painter = splashPainter,
+                    contentDescription = description,
+                    modifier = Modifier
+                        .width(260.dp)
+                        .height(320.dp),
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                Text(
+                    text = "Diana",
+                    style = MaterialTheme.typography.headlineMedium.copy(
+                        color = Color(0xFFEFE7FF),
+                        letterSpacing = 2.sp,
+                    ),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = "Guardian of captured thoughts",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        color = Color(0xFFD1C5FF),
+                        textAlign = TextAlign.Center,
+                    ),
+                )
+                Spacer(modifier = Modifier.height(32.dp))
+                Text(
+                    text = "build v$versionName",
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        color = Color(0xFFB9AFFF),
+                        fontFamily = FontFamily.Monospace,
+                        letterSpacing = 1.5.sp,
+                    ),
+                )
+            }
+        }
+    }
+}
+
+private val dianaHuntressVector: ImageVector by lazy {
+    ImageVector.Builder(
+        name = "DianaHuntress",
+        defaultWidth = 260.dp,
+        defaultHeight = 320.dp,
+        viewportWidth = 260f,
+        viewportHeight = 320f,
+    ).apply {
+        path(
+            fill = SolidColor(Color(0xFF261040)),
+            pathFillType = PathFillType.NonZero,
+        ) {
+            addPathNodes("M130 16C64.486 16 12 68.486 12 134s52.486 118 118 118 118-52.486 118-118S195.514 16 130 16z")
+        }
+        path(
+            fill = SolidColor(Color(0xFF3C1F6A)),
+            pathFillType = PathFillType.NonZero,
+        ) {
+            addPathNodes("M182 32c43.96 18.88 74 64.44 74 108 0 64.88-43.84 123.32-108 145.6 40.96-44.72 49.04-110.16 27.6-164.16C165.2 86.84 154.6 62.96 182 32z")
+        }
+        path(
+            fill = SolidColor(Color(0xFFF3CEA0)),
+            pathFillType = PathFillType.NonZero,
+        ) {
+            addPathNodes("M144 58a24 24 0 1 1 48 0 24 24 0 1 1-48 0z")
+        }
+        path(
+            fill = SolidColor(Color(0xFF4A2A86)),
+            pathFillType = PathFillType.NonZero,
+        ) {
+            addPathNodes("M148 90c25.84 31.56 41.28 72.44 38.12 112.64-3.16 40.08-22.04 78.8-52.12 107.36-20.96-24.48-32.52-50.6-33.96-78.24-1.44-27.4 6.28-55.72 20.92-85.04l-32.36 10.08C101.52 124.72 117.8 94.72 148 90z")
+        }
+        path(
+            fill = SolidColor(Color(0xFF6A3FB4)),
+            pathFillType = PathFillType.NonZero,
+        ) {
+            addPathNodes("M128 128c-25.2 27.28-36.76 59.12-32.4 92 3.64 25.76 16.28 49.28 36 69.6-44.16-14.08-75.4-51.04-80.4-88.96C46.44 154.16 74.04 130.16 128 128z")
+        }
+        path(
+            fill = SolidColor(Color(0xFFBFA1FF)),
+            stroke = SolidColor(Color(0xFFBFA1FF)),
+            strokeLineWidth = 10f,
+            strokeLineCap = StrokeCap.Round,
+            strokeLineJoin = StrokeJoin.Round,
+            pathFillType = PathFillType.NonZero,
+        ) {
+            addPathNodes("M52 148c43.2-79.2 164.4-84 216 24-45.6 113.2-172.8 112.4-216-24z")
+        }
+        path(
+            fill = SolidColor(Color(0xFFF5D680)),
+            stroke = SolidColor(Color(0xFFF5D680)),
+            strokeLineWidth = 6f,
+            strokeLineCap = StrokeCap.Round,
+            strokeLineJoin = StrokeJoin.Round,
+            pathFillType = PathFillType.NonZero,
+        ) {
+            addPathNodes("M94 210l118-28")
+        }
+        path(
+            fill = SolidColor(Color(0xFFF5D680)),
+            pathFillType = PathFillType.NonZero,
+        ) {
+            addPathNodes("M214 176l18 14-24 8z")
+        }
+        path(
+            fill = SolidColor(Color(0xFF201138)),
+            pathFillType = PathFillType.NonZero,
+        ) {
+            addPathNodes("M168 82c10.32 4.4 19.72 10.72 26.96 18.8 4.16 4.52 7.44 9.24 9.2 14.44 1.36 4.12 1.52 8.64.48 13.56l-20.28-6.36c1.8-8.12.72-15.16-3.24-21.04-4.12-6.12-10.56-10.28-18.36-12.32z")
+        }
+    }.build()
+}
+
+@Preview(name = "Splash screen", showBackground = true, backgroundColor = 0xFF1A1038)
+@Composable
+private fun SplashScreenPreview() {
+    DianaTheme {
+        SplashScreen(versionName = "0.1")
+    }
+}

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -65,4 +65,5 @@
     <string name="add_label">Ajouter un libellé</string>
     <string name="delete_label">Supprimer le libellé</string>
     <string name="delete_tag">Supprimer le tag</string>
+    <string name="splash_diana_content_description">Illustration de Diane bandant son arc.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -65,4 +65,5 @@
     <string name="add_label">Aggiungi etichetta</string>
     <string name="delete_label">Elimina etichetta</string>
     <string name="delete_tag">Elimina tag</string>
+    <string name="splash_diana_content_description">Illustrazione di Diana che tende il suo arco.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,4 +89,5 @@
     <string name="add_label">Add label</string>
     <string name="delete_label">Delete label</string>
     <string name="delete_tag">Delete tag</string>
+    <string name="splash_diana_content_description">Illustration of Diana drawing her bow.</string>
 </resources>

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -6,6 +6,7 @@ This log captures active initiatives and recent pushes so contributors can orien
 
 | Date       | Status      | Summary | Further detail |
 | ---------- | ----------- | ------- | -------------- |
+| 2025-09-27 | Shipped     | Compose splash screen with huntress illustration and build badge gating startup. | [Splash screen concept](thoughts/splashscreen.md) — UI polish; splash shown for ~1.2s while app boots. |
 | 2025-09-26 | Shipped     | Memo prompt placeholders now replace `{date}` for scripts and Android to keep LLM instructions accurate. | [Memo date placeholder notes](thoughts/memo-date-placeholder.md) — Tests: `scripts/tests/test_notes_tools.py`. |
 | 2025-09-24 | In progress | Firebase notes scripting to backfill memo metadata and align Firestore exports with the memo processor. | [Firebase notes scripting plan](thoughts/firebase-notes-scripts.md) |
 | 2025-09-24 | Shipped     | Delete-session dialog polished with vertically stacked Material buttons to preserve touch targets. | Verified via Compose previews on phone and tablet widths. |

--- a/docs/assets/diana_splash.svg
+++ b/docs/assets/diana_splash.svg
@@ -1,0 +1,22 @@
+<svg width="780" height="960" viewBox="0 0 260 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bgGradient" cx="30%" cy="18%" r="80%">
+      <stop offset="0%" stop-color="#150233"/>
+      <stop offset="55%" stop-color="#251158"/>
+      <stop offset="100%" stop-color="#351C70"/>
+    </radialGradient>
+  </defs>
+  <rect width="260" height="320" fill="url(#bgGradient)"/>
+  <g transform="translate(0,12)">
+    <path d="M130 4C64.486 4 12 56.486 12 122s52.486 118 118 118 118-52.486 118-118S195.514 4 130 4z" fill="#261040"/>
+    <path d="M182 20c43.96 18.88 74 64.44 74 108 0 64.88-43.84 123.32-108 145.6 40.96-44.72 49.04-110.16 27.6-164.16C165.2 74.84 154.6 50.96 182 20z" fill="#3C1F6A"/>
+    <path d="M144 46a24 24 0 1 1 48 0 24 24 0 1 1-48 0z" fill="#F3CEA0"/>
+    <path d="M148 78c25.84 31.56 41.28 72.44 38.12 112.64-3.16 40.08-22.04 78.8-52.12 107.36-20.96-24.48-32.52-50.6-33.96-78.24-1.44-27.4 6.28-55.72 20.92-85.04l-32.36 10.08C101.52 112.72 117.8 82.72 148 78z" fill="#4A2A86"/>
+    <path d="M128 116c-25.2 27.28-36.76 59.12-32.4 92 3.64 25.76 16.28 49.28 36 69.6-44.16-14.08-75.4-51.04-80.4-88.96C46.44 142.16 74.04 118.16 128 116z" fill="#6A3FB4"/>
+    <path d="M52 136c43.2-79.2 164.4-84 216 24-45.6 113.2-172.8 112.4-216-24z" stroke="#BFA1FF" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="#BFA1FF" fill-opacity="0.08"/>
+    <path d="M94 198l118-28" stroke="#F5D680" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M214 164l18 14-24 8z" fill="#F5D680"/>
+    <path d="M168 70c10.32 4.4 19.72 10.72 26.96 18.8 4.16 4.52 7.44 9.24 9.2 14.44 1.36 4.12 1.52 8.64.48 13.56l-20.28-6.36c1.8-8.12.72-15.16-3.24-21.04-4.12-6.12-10.56-10.28-18.36-12.32z" fill="#201138"/>
+  </g>
+  <text x="130" y="294" text-anchor="middle" font-family="'IBM Plex Mono', 'Courier New', monospace" font-size="12" fill="#B9AFFF">build v0.1</text>
+</svg>

--- a/docs/thoughts/splashscreen.md
+++ b/docs/thoughts/splashscreen.md
@@ -1,0 +1,24 @@
+# Splash screen concept
+
+## Task list
+1. Update WORKLOG.md with a splash-screen initiative entry and seed this thought note for collaboration.
+2. Audit the Compose startup flow to confirm how a splash state can gate the main application surface.
+3. Illustrate a huntress silhouette in vector form, anchored by a lunar backdrop inspired by Diana mythology.
+4. Build a reusable Compose `SplashScreen` that renders the vector art alongside brand copy.
+5. Bind the BuildConfig version string into the splash layout using a compact monospace treatment.
+6. Export the illustration as a standalone SVG asset and describe usage expectations.
+7. Refresh WORKLOG.md and this note with implementation outcomes so the documentation stays in sync.
+
+## Visual direction
+- Palette leans into deep violets and moonlit golds already present in the Diana branding.
+- Illustration evokes a poised archer framed by a crescent glow to telegraph focus and readiness.
+- Typography contrasts a refined display for the product name with a utilitarian monospace build stamp.
+
+## Implementation snapshot
+- `SplashScreen` Compose surface wraps the illustration, tagline, and build version badge.
+- Startup flow in `MainActivity` holds the main UI behind a short-lived splash state to avoid abrupt transitions while Firebase bootstraps.
+- The SVG asset in `docs/assets/diana_splash.svg` mirrors the on-device vector so design teams can iterate without decompiling the app.
+
+## Follow-ups
+- Consider animating subtle bow tension or gradient shimmer using Compose `InfiniteTransition` once performance impact is profiled.
+- Evaluate showing session-sync progress on the splash if remote bootstrap time grows.


### PR DESCRIPTION
## Summary
- add a Compose splash screen that renders a Diana huntress illustration and the build version badge
- gate the main surfaces behind a short splash state during startup
- document the splash work and check in the standalone SVG reference asset with translations for its content description

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain *(fails: existing ExperimentalMaterial3 API usages in MemoArchiveScreen and TagCatalogScreen)*

------
https://chatgpt.com/codex/tasks/task_e_68e6256f31ec8325850ab0e8493f1c12