### PR TITLE
Add apply/undo support for TodoChangeSet in NoteRepository

### DIFF
--- a/app/src/main/java/li/crescio/penates/diana/llm/TodoChangeSet.kt
+++ b/app/src/main/java/li/crescio/penates/diana/llm/TodoChangeSet.kt
@@ -14,4 +14,5 @@ data class TodoChangeSet(
     val model: String,
     val promptVersion: String,
     val actions: List<TodoAction>,
+    val type: String = "apply",
 )


### PR DESCRIPTION
### Motivation
- Provide an API to apply or undo a `TodoChangeSet` so LLM-generated todo diffs can be executed or reverted programmatically.
- Ensure undo operations are implemented by inverting each `TodoAction` (add ↔ delete, update swaps `before`/`after`) rather than mutating the original change set.
- Persist both the resulting notes and an audit entry for the undo into local storage and Firestore for traceability.

### Description
- Added a `type` field to `TodoChangeSet` and included it in normalization and JSON serialization so change sets can be classified (e.g. `apply` vs `undo`).
- Implemented `applyTodoChangeSet(changeSet, mode)` on `NoteRepository` and a `TodoChangeSetMode` enum to support `APPLY` and `UNDO` workflows.
- For `UNDO`, the method inverts each `TodoAction` via `invertTodoAction`, applies the inverted actions to local notes and to Firestore using a `batch`, and writes an independent undo `TodoChangeSet` (new id/timestamp and `type = "undo"`) to Firestore and the local `todo_change_sets` file.
- Added helpers `todoItemToNote`, `todoStableKey` (reusing `TodoDiff.stableKey`), and logic to keep local `notesFile` synchronized with Firestore after applying actions.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698885e9ee848325be0b39d185f25e66)